### PR TITLE
C++14 support (replacing C++17-only features)

### DIFF
--- a/include/container/seadPtrArray.h
+++ b/include/container/seadPtrArray.h
@@ -160,17 +160,18 @@ protected:
     void sort_(Compare cmp)
     {
         // Note: Nintendo did not use <algorithm>
-        std::sort(mPtrs, mPtrs + size(),
-                  [&](const void* a, const void* b)
-                  { return cmp(static_cast<const T*>(a), static_cast<const T*>(b)) < 0; });
+        std::sort(mPtrs, mPtrs + size(), [&](const void* a, const void* b) {
+            return cmp(static_cast<const T*>(a), static_cast<const T*>(b)) < 0;
+        });
     }
 
     template <typename T, typename Compare>
     void heapSort_(Compare cmp)
     {
         // Note: Nintendo did not use <algorithm>
-        const auto less_cmp = [&](const void* a, const void* b)
-        { return cmp(static_cast<const T*>(a), static_cast<const T*>(b)) < 0; };
+        const auto less_cmp = [&](const void* a, const void* b) {
+            return cmp(static_cast<const T*>(a), static_cast<const T*>(b)) < 0;
+        };
         std::make_heap(mPtrs, mPtrs + size(), less_cmp);
         std::sort_heap(mPtrs, mPtrs + size(), less_cmp);
     }

--- a/include/filedevice/nin/seadNinSDFileDeviceNin.h
+++ b/include/filedevice/nin/seadNinSDFileDeviceNin.h
@@ -13,4 +13,4 @@ public:
 
     bool doIsAvailable_() const override;
 };
-}
+}  // namespace sead

--- a/include/prim/seadPtrUtil.h
+++ b/include/prim/seadPtrUtil.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <basis/seadTypes.h>
 #include <basis/seadRawPrint.h>
+#include <basis/seadTypes.h>
 
 namespace sead
 {

--- a/include/resource/seadDecompressor.h
+++ b/include/resource/seadDecompressor.h
@@ -13,7 +13,9 @@ namespace sead
 class Decompressor : public TListNode<Decompressor*>, public IDisposer
 {
 public:
-    Decompressor(const SafeString& name) : TListNode<Decompressor*>(this), IDisposer(), mExt(name) {}
+    Decompressor(const SafeString& name) : TListNode<Decompressor*>(this), IDisposer(), mExt(name)
+    {
+    }
 
     virtual ~Decompressor()
     {

--- a/modules/src/resource/seadSharcArchiveRes.cpp
+++ b/modules/src/resource/seadSharcArchiveRes.cpp
@@ -226,7 +226,7 @@ bool SharcArchiveRes::prepareArchive_(const void* archive)
     const u8* archive_ = reinterpret_cast<const u8*>(archive);
 
     mArchiveBlockHeader = reinterpret_cast<const ArchiveBlockHeader*>(archive_);
-    if(std::memcmp(mArchiveBlockHeader->signature, "SARC", 4) != 0)
+    if (std::memcmp(mArchiveBlockHeader->signature, "SARC", 4) != 0)
     {
         SEAD_ASSERT_MSG(false, "Invalid ArchiveBlockHeader");
         return false;
@@ -250,7 +250,7 @@ bool SharcArchiveRes::prepareArchive_(const void* archive)
 
     mFATBlockHeader = reinterpret_cast<const FATBlockHeader*>(
         archive_ + Endian::toHostU16(mEndianType, mArchiveBlockHeader->header_size));
-    if(std::memcmp(mFATBlockHeader->signature, "SFAT", 4) != 0)
+    if (std::memcmp(mFATBlockHeader->signature, "SFAT", 4) != 0)
     {
         SEAD_ASSERT_MSG(false, "Invalid FATBlockHeader");
         return false;
@@ -278,7 +278,7 @@ bool SharcArchiveRes::prepareArchive_(const void* archive)
         archive_ + Endian::toHostU16(mEndianType, mArchiveBlockHeader->header_size) +
         Endian::toHostU16(mEndianType, mFATBlockHeader->header_size) +
         Endian::toHostU16(mEndianType, mFATBlockHeader->file_num) * sizeof(FATEntry));
-    if(std::memcmp(fnt_header->signature, "SFNT", 4) != 0)
+    if (std::memcmp(fnt_header->signature, "SFNT", 4) != 0)
     {
         SEAD_ASSERT_MSG(false, "Invalid FNTBlockHeader");
         return false;

--- a/modules/src/resource/seadSharcArchiveRes.cpp
+++ b/modules/src/resource/seadSharcArchiveRes.cpp
@@ -1,5 +1,3 @@
-#include <string_view>
-
 #include <container/seadBuffer.h>
 #include <prim/seadPtrUtil.h>
 #include <prim/seadSafeString.h>
@@ -228,7 +226,7 @@ bool SharcArchiveRes::prepareArchive_(const void* archive)
     const u8* archive_ = reinterpret_cast<const u8*>(archive);
 
     mArchiveBlockHeader = reinterpret_cast<const ArchiveBlockHeader*>(archive_);
-    if (std::string_view(mArchiveBlockHeader->signature, 4) != "SARC")
+    if(std::memcmp(mArchiveBlockHeader->signature, "SARC", 4) != 0)
     {
         SEAD_ASSERT_MSG(false, "Invalid ArchiveBlockHeader");
         return false;
@@ -252,7 +250,7 @@ bool SharcArchiveRes::prepareArchive_(const void* archive)
 
     mFATBlockHeader = reinterpret_cast<const FATBlockHeader*>(
         archive_ + Endian::toHostU16(mEndianType, mArchiveBlockHeader->header_size));
-    if (std::string_view(mFATBlockHeader->signature, 4) != "SFAT")
+    if(std::memcmp(mFATBlockHeader->signature, "SFAT", 4) != 0)
     {
         SEAD_ASSERT_MSG(false, "Invalid FATBlockHeader");
         return false;
@@ -280,7 +278,7 @@ bool SharcArchiveRes::prepareArchive_(const void* archive)
         archive_ + Endian::toHostU16(mEndianType, mArchiveBlockHeader->header_size) +
         Endian::toHostU16(mEndianType, mFATBlockHeader->header_size) +
         Endian::toHostU16(mEndianType, mFATBlockHeader->file_num) * sizeof(FATEntry));
-    if (std::string_view(fnt_header->signature, 4) != "SFNT")
+    if(std::memcmp(fnt_header->signature, "SFNT", 4) != 0)
     {
         SEAD_ASSERT_MSG(false, "Invalid FNTBlockHeader");
         return false;


### PR DESCRIPTION
To support `clang-3.9.1` for building Super Mario Odyssey, `C++17` features have to be dropped. Here, this results in one major change:
As `string_view` gets unusable, the signatures of blocks in `modules/src/resource/seadSharcArchiveRes.cpp` can't be checked using that. Instead, `std::strncmp` is used then.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/82)
<!-- Reviewable:end -->
