### PR TITLE
prim/Enum: Remove wrong comment

### DIFF
--- a/include/prim/seadEnum.h
+++ b/include/prim/seadEnum.h
@@ -40,8 +40,6 @@ private:
 ///
 /// SEAD_ENUM(CoreId, cMain, cSub1, cSub2)
 ///
-/// Finally, in the .cpp file, add SEAD_ENUM_IMPL(CoreId)
-///
 #define SEAD_ENUM(NAME, ...)                                                                       \
     class NAME                                                                                     \
     {                                                                                              \


### PR DESCRIPTION
As there is no macro for `SEAD_ENUM_IMPL` and it is not required, the comment removed in this PR is not only wrong, but also misleading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/83)
<!-- Reviewable:end -->
