### PR TITLE
controller: Add `seadController`, `Base` and `Mgr`

### DIFF
--- a/include/controller/seadController.h
+++ b/include/controller/seadController.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "container/seadOffsetList.h"
+#include "controller/seadControllerBase.h"
+
+namespace sead
+{
+class ControllerMgr;
+class ControllerAddon;
+
+namespace ControllerDefine
+{
+enum AddonId : int
+{
+};
+enum ControllerId : int
+{
+    _15 = 15,
+    _16 = 16
+};
+enum DeviceId : int
+{
+};
+
+}  // namespace ControllerDefine
+
+class Controller : public ControllerBase
+{
+    SEAD_RTTI_OVERRIDE(Controller, ControllerBase)
+public:
+    Controller(ControllerMgr*);
+    virtual ~Controller();
+    virtual void calc();
+    virtual bool isConnected();
+    ControllerAddon* getAddonByOrder(ControllerDefine::AddonId, int);
+    ControllerAddon* getAddon(ControllerDefine::AddonId);
+
+protected:
+    virtual void calcImpl_() = 0;
+    virtual bool isIdle_();
+    virtual void setIdle_();
+
+private:
+    int mControllerId;
+    ControllerMgr* mMgr;
+    OffsetList<ControllerAddon> mAddonList;
+    OffsetList<void*> _160;  // unknown type
+};
+
+}  // namespace sead

--- a/include/controller/seadControllerBase.h
+++ b/include/controller/seadControllerBase.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "math/seadBoundBox.h"
+#include "math/seadVector.h"
+#include "prim/seadRuntimeTypeInfo.h"
+#include "prim/seadTypedBitFlag.h"
+
+namespace sead
+{
+class ControllerBase
+{
+    SEAD_RTTI_BASE(ControllerBase)
+public:
+    ControllerBase(int, int, int, int);
+
+    void setRightStickCrossThreshold(float, float);
+    void setPointerBound(const BoundBox2f& bound);
+    void setPadRepeat(u32, u8, u8);
+    void setLeftStickCrossThreshold(float, float);
+    // unknown return type
+    u32 getPadHoldCount(int) const;
+
+    int getButtonsTrigger() const { return mButtonsTrigger; }
+    int getButtonsRelease() const { return mButtonsRelease; }
+    int getButtonsRepeat() const { return mButtonsRepeat; }
+    int getButtonsHold() const { return mButtonsHold; }
+    const Vector2f& getTouchScreenPos() const { return mTouchScreenPos; }
+    const Vector2f& getLeftJoy() const { return mLeftJoy; }
+    const Vector2f& getRightJoy() const { return mRightJoy; }
+
+protected:
+    void updateDerivativeParams_(u32, bool);
+    void setPointerWithBound_(bool, bool, const Vector2f& bound);
+    void setIdleBase_();
+    bool isIdleBase_();
+    // unknown return type
+    u32 getStickHold_(u32, const Vector2f&, float, float, int);
+    // unknown return type
+    u32 createStickCrossMask_();
+
+private:
+    int mButtonsTrigger;
+    int mButtonsRelease;
+    unsigned int mButtonsRepeat;
+    unsigned int mFlags;
+    int _18;
+    int _1c;
+    BoundBox2f mPointerBound;
+    int mPadHoldCounts[32];
+    char _b0[32];
+    char _d0[32];
+    float mLeftStickThresholdX;
+    float mRightStickThresholdX;
+    float mLeftStickThresholdY;
+    float mRightStickThresholdY;
+    int _100;
+    int _104;
+    int _108;
+    int _10c;
+    unsigned int mIdleCounter;
+    unsigned int mButtonsHold;
+    Vector2f mTouchScreenPos;
+    Vector2f mLeftJoy;
+    Vector2f mRightJoy;
+    Vector2f _130;
+};
+
+}  // namespace sead

--- a/include/controller/seadControllerMgr.h
+++ b/include/controller/seadControllerMgr.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "container/seadOffsetList.h"
+#include "container/seadPtrArray.h"
+#include "controller/seadController.h"
+#include "framework/seadCalculateTask.h"
+#include "framework/seadTaskMgr.h"
+#include "heap/seadDisposer.h"
+
+namespace sead
+{
+class Controller;
+class NinJoyNpadDevice;
+
+class ControllerMgr : public CalculateTask
+{
+    SEAD_TASK_SINGLETON(ControllerMgr)
+public:
+    explicit ControllerMgr(const TaskConstructArg& arg);
+    ControllerMgr();
+
+    void calc() override;
+    void finalize();
+    void finalizeDefault();
+    int findControllerPort(const Controller* controller);
+    NinJoyNpadDevice* getControlDevice(ControllerDefine::DeviceId device_id);
+    // unknown return type
+    void* getControllerAddon(int, ControllerDefine::AddonId addon_id);
+    // unknown return type
+    void* getControllerAddonByOrder(int, ControllerDefine::AddonId addon_id, int);
+    Controller* getControllerByOrder(ControllerDefine::ControllerId controller_id, int);
+    // unknown return type, probably inherited from TaskBase
+    void* getFramework();
+    void initialize(int, Heap* heap);
+    void initializeDefault(Heap* heap);
+    void prepare() override;
+
+    Controller* getController(int port) { return mArray[port]; }
+
+private:
+    OffsetList<NinJoyNpadDevice> mList;
+    PtrArray<Controller> mArray;
+};
+
+}  // namespace sead

--- a/include/framework/seadTaskMgr.h
+++ b/include/framework/seadTaskMgr.h
@@ -103,7 +103,7 @@ protected:                                                                      
         if (!sInstance)                                                                            \
         {                                                                                          \
             sInstance = static_cast<CLASS*>(task);                                                 \
-            sInstance.mSingletonDisposer.mActive = true;                                           \
+            sInstance->mSingletonDisposer.mActive = true;                                          \
         }                                                                                          \
         else                                                                                       \
         {                                                                                          \


### PR DESCRIPTION
This PR adds some part of the input-related stuff into the decomp. These are the "frontend-classes", so the ones that games will most likely interact with. `SMO` uses another bunch of utility functions to read specific bits from the `seadControllerBase->mButtonTrigger`/... fields, so probably there is a similar system in place for other games too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/89)
<!-- Reviewable:end -->
