### PR TITLE
math: Add `makeQT` to Matrix and `setRPY` to Quat

### DIFF
--- a/include/math/seadMatrix.h
+++ b/include/math/seadMatrix.h
@@ -136,6 +136,7 @@ public:
     void transpose();
 
     void fromQuat(const Quat& q);
+    void makeQT(const Quat& q, const Vec3& t);
     void makeR(const Vec3& r);
     void makeRIdx(u32 xr, u32 yr, u32 zr);
     void makeRT(const Vec3& r, const Vec3& t);

--- a/include/math/seadMatrix.hpp
+++ b/include/math/seadMatrix.hpp
@@ -346,6 +346,12 @@ inline void Matrix34<T>::fromQuat(const Quat& q)
 }
 
 template <typename T>
+inline void Matrix34<T>::makeQT(const Quat& q, const Vec3& t)
+{
+    Matrix34CalcCommon<T>::makeQT(*this, q, t);
+}
+
+template <typename T>
 inline void Matrix34<T>::makeR(const Vec3& r)
 {
     Matrix34CalcCommon<T>::makeR(*this, r);

--- a/include/math/seadMatrixCalcCommon.h
+++ b/include/math/seadMatrixCalcCommon.h
@@ -87,6 +87,7 @@ public:
     static void transposeTo(Base& o, const Base& n);
 
     static void makeQ(Base& o, const Quat& q);
+    static void makeQT(Base& o, const Quat& q, const Vec3& t);
     static void makeR(Base& o, const Vec3& r);
     static void makeRIdx(Base& o, u32 xr, u32 yr, u32 zr);
     static void makeRT(Base& o, const Vec3& r, const Vec3& t);

--- a/include/math/seadMatrixCalcCommon.hpp
+++ b/include/math/seadMatrixCalcCommon.hpp
@@ -1208,6 +1208,38 @@ void Matrix34CalcCommon<T>::makeQ(Base& o, const Quat& q)
 }
 
 template <typename T>
+void Matrix34CalcCommon<T>::makeQT(Base& o, const Quat& q, const Vec3& t)
+{
+    // Assuming the quaternion "q" is normalized
+
+    const T yy = 2 * q.y * q.y;
+    const T zz = 2 * q.z * q.z;
+    const T xx = 2 * q.x * q.x;
+    const T xy = 2 * q.x * q.y;
+    const T xz = 2 * q.x * q.z;
+    const T yz = 2 * q.y * q.z;
+    const T wz = 2 * q.w * q.z;
+    const T wx = 2 * q.w * q.x;
+    const T wy = 2 * q.w * q.y;
+
+    o.m[0][0] = 1 - yy - zz;
+    o.m[0][1] = xy - wz;
+    o.m[0][2] = xz + wy;
+
+    o.m[1][0] = xy + wz;
+    o.m[1][1] = 1 - xx - zz;
+    o.m[1][2] = yz - wx;
+
+    o.m[2][0] = xz - wy;
+    o.m[2][1] = yz + wx;
+    o.m[2][2] = 1 - xx - yy;
+
+    o.m[0][3] = t.x;
+    o.m[1][3] = t.y;
+    o.m[2][3] = t.z;
+}
+
+template <typename T>
 void Matrix34CalcCommon<T>::makeR(Base& o, const Vec3& r)
 {
     const T sinV[3] = {MathCalcCommon<T>::sin(r.x), MathCalcCommon<T>::sin(r.y),

--- a/include/math/seadQuat.h
+++ b/include/math/seadQuat.h
@@ -64,6 +64,7 @@ public:
     void makeUnit();
     bool makeVectorRotation(const Vec3& from, const Vec3& to);
     void set(T w, T x, T y, T z);
+    void setRPY(T roll, T pitch, T yaw);
 
     static const Quat unit;
 };

--- a/include/math/seadQuat.hpp
+++ b/include/math/seadQuat.hpp
@@ -79,4 +79,10 @@ inline void Quat<T>::set(T w_, T x_, T y_, T z_)
     QuatCalcCommon<T>::set(*this, w_, x_, y_, z_);
 }
 
+template <typename T>
+inline void Quat<T>::setRPY(T roll, T pitch, T yaw)
+{
+    QuatCalcCommon<T>::setRPY(*this, roll, pitch, yaw);
+}
+
 }  // namespace sead

--- a/include/math/seadQuatCalcCommon.h
+++ b/include/math/seadQuatCalcCommon.h
@@ -19,6 +19,7 @@ public:
     static void makeUnit(Base& q);
     static bool makeVectorRotation(Base& q, const Vec3& from, const Vec3& to);
     static void set(Base& q, T w, T x, T y, T z);
+    static void setRPY(Base& q, T roll, T pitch, T yaw);
 };
 
 }  // namespace sead

--- a/include/math/seadQuatCalcCommon.hpp
+++ b/include/math/seadQuatCalcCommon.hpp
@@ -129,17 +129,22 @@ inline void QuatCalcCommon<T>::set(Base& q, T w, T x, T y, T z)
 template <typename T>
 inline void QuatCalcCommon<T>::setRPY(Base& q, T roll, T pitch, T yaw)
 {
-    float cy = std::cos(yaw * 0.5f);
-    float cp = std::cos(pitch * 0.5f);
-    float cr = std::cos(roll * 0.5f);
-    float sy = std::sin(yaw * 0.5f);
-    float sp = std::sin(pitch * 0.5f);
-    float sr = std::sin(roll * 0.5f);
+    const T cy = std::cos(yaw / 2);
+    const T cp = std::cos(pitch / 2);
+    const T cr = std::cos(roll / 2);
+    const T sy = std::sin(yaw / 2);
+    const T sp = std::sin(pitch / 2);
+    const T sr = std::sin(roll / 2);
 
-    float w = (cy * cp * cr) + (sy * sp * sr);
-    float x = (cy * cp * sr) - (sy * sp * cr);
-    float y = (cy * sp * cr) + (sy * cp * sr);
-    float z = (sy * cp * cr) - (cy * sp * sr);
+    const T cy_cp = cy * cp;
+    const T sy_sp = sy * sp;
+    const T cy_sp = cy * sp;
+    const T sy_cp = sy * cp;
+
+    const T w = (cy_cp * cr) + (sy_sp * sr);
+    const T x = (cy_cp * sr) - (sy_sp * cr);
+    const T y = (cy_sp * cr) + (sy_cp * sr);
+    const T z = (sy_cp * cr) - (cy_sp * sr);
 
     set(q, w, x, y, z);
 }

--- a/include/math/seadQuatCalcCommon.hpp
+++ b/include/math/seadQuatCalcCommon.hpp
@@ -126,4 +126,22 @@ inline void QuatCalcCommon<T>::set(Base& q, T w, T x, T y, T z)
     q.z = z;
 }
 
+template <typename T>
+inline void QuatCalcCommon<T>::setRPY(Base& q, T roll, T pitch, T yaw)
+{
+    float cy = std::cos(yaw * 0.5f);
+    float cp = std::cos(pitch * 0.5f);
+    float cr = std::cos(roll * 0.5f);
+    float sy = std::sin(yaw * 0.5f);
+    float sp = std::sin(pitch * 0.5f);
+    float sr = std::sin(roll * 0.5f);
+
+    float w = (cy * cp * cr) + (sy * sp * sr);
+    float x = (cy * cp * sr) - (sy * sp * cr);
+    float y = (cy * sp * cr) + (sy * cp * sr);
+    float z = (sy * cp * cr) - (cy * sp * sr);
+
+    set(q, w, x, y, z);
+}
+
 }  // namespace sead


### PR DESCRIPTION
Both are used by Super Mario Odyssey in the `ActorPoseKeeper` classes.

Maybe the `setRPY` function is a `Quatf`-specific one and should not be generalized to all types?

Example usages:
`makeQT`:
```cpp
void ActorPoseKeeperTQSV::calcBaseMtx(sead::Matrix34f* mtx) const {
    mtx->makeQT(mQuat, mTrans);
}
```
`setRPY`:
```cpp
void ActorPoseKeeperBase::updatePoseRotate(const sead::Vector3f& rot) {
    sead::Quatf quat;
    quat.setRPY(sead::Mathf::deg2rad(rot.x), sead::Mathf::deg2rad(rot.y), sead::Mathf::deg2rad(rot.z));
    updatePoseQuat(quat);
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/95)
<!-- Reviewable:end -->
