### PR TITLE
`thread/nin`: Fix EventNin/ n::os::LightEvent-call

### DIFF
--- a/modules/src/thread/nin/seadEventNin.cpp
+++ b/modules/src/thread/nin/seadEventNin.cpp
@@ -41,7 +41,9 @@ void Event::initialize(bool manual_reset)
 #ifdef SEAD_DEBUG
     SEAD_ASSERT_MSG(!mInitialized, "Event is already initialized.");
 #endif
-    nn::os::InitializeLightEvent(&mEventInner, false, !manual_reset);
+    nn::os::InitializeLightEvent(&mEventInner, false,
+                                 manual_reset ? nn::os::EventClearMode_ManualClear :
+                                                nn::os::EventClearMode_AutoClear);
     setInitialized(true);
 }
 


### PR DESCRIPTION
Due to recent changes in the `NintendoSDK`-headers, one function definition has been changed that is used locally, resulting in compile errors.

https://github.com/open-ead/sead/tree/8cb5a828b9def35496fc91bfdd3390ca64d247fb/modules/src/thread/nin/seadEventNin.cpp#L44
Tries to call nn::os::InitializeLightEvent with two boolean parameters (2nd and 3rd parameter), but

https://github.com/open-ead/nnheaders/blob/b15fa31fd4508590bad50473da9fd922a1e7e009/include/nn/os.h#L197
Accepts one boolean and one EventClearMode instead.

This PR fixes this, by adding a ternary to the call to call the function with the two possible values of `EventClearMode` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/97)
<!-- Reviewable:end -->
