### PR TITLE
`math`: Improvements on `Matrix34` and `Quat`

### DIFF
--- a/include/math/seadMathCalcCommon.h
+++ b/include/math/seadMathCalcCommon.h
@@ -55,7 +55,7 @@ public:
     /// Returns -1 for strictly negative values and 1 otherwise.
     static T sign(T value);
 
-    static T fitSign(T value, T sign_value) { return value * sign(sign_value); }
+    static T fitSign(T value, T sign_value) { return abs(value) * sign(sign_value); }
 
     static T square(T t) { return t * t; }
 

--- a/include/math/seadMatrix.h
+++ b/include/math/seadMatrix.h
@@ -159,6 +159,7 @@ public:
     void getBase(Vec3& o, s32 axis) const;
     void getRow(Vec4& o, s32 row) const;
     void getTranslation(Vec3& o) const;
+    void getRotation(Vec3& o) const;
 
     void scaleAllElements(T s);
     void scaleBases(T sx, T sy, T sz);

--- a/include/math/seadMatrix.hpp
+++ b/include/math/seadMatrix.hpp
@@ -480,6 +480,12 @@ inline void Matrix34<T>::getTranslation(Vec3& o) const
 }
 
 template <typename T>
+inline void Matrix34<T>::getRotation(Vec3& o) const
+{
+    Matrix34CalcCommon<T>::getRotation(o, *this);
+}
+
+template <typename T>
 inline void Matrix34<T>::scaleAllElements(T s)
 {
     Matrix34CalcCommon<T>::scaleAllElements(*this, s);

--- a/include/math/seadMatrixCalcCommon.h
+++ b/include/math/seadMatrixCalcCommon.h
@@ -108,6 +108,7 @@ public:
     static void getBase(Vec3& v, const Base& n, s32 axis);
     static void getRow(Vec4& v, const Base& n, s32 row);
     static void getTranslation(Vec3& v, const Base& n);
+    static void getRotation(Vec3& v, const Base& n);
 
     static void scaleAllElements(Base& n, T s);
     static void scaleBases(Base& n, T sx, T sy, T sz);

--- a/include/math/seadMatrixCalcCommon.hpp
+++ b/include/math/seadMatrixCalcCommon.hpp
@@ -1293,25 +1293,27 @@ void Matrix34CalcCommon<T>::makeRIdx(Base& o, u32 xr, u32 yr, u32 zr)
 }
 
 template <typename T>
-void Matrix34CalcCommon<T>::makeRT(Base& o, const Vec3& r, const Vec3& t)
+inline void Matrix34CalcCommon<T>::makeRT(Base& o, const Vec3& r, const Vec3& t)
 {
-    const T sinV[3] = {MathCalcCommon<T>::sin(r.x), MathCalcCommon<T>::sin(r.y),
-                       MathCalcCommon<T>::sin(r.z)};
+    const T sinV[3] = {std::sin(r.x), std::sin(r.y), std::sin(r.z)};
 
-    const T cosV[3] = {MathCalcCommon<T>::cos(r.x), MathCalcCommon<T>::cos(r.y),
-                       MathCalcCommon<T>::cos(r.z)};
+    const T cosV[3] = {std::cos(r.x), std::cos(r.y), std::cos(r.z)};
 
-    o.m[0][0] = (cosV[1] * cosV[2]);
-    o.m[1][0] = (cosV[1] * sinV[2]);
+    T s0_s1 = sinV[0] * sinV[1];
+    T c0_s2 = cosV[0] * sinV[2];
+    T c0_c2 = cosV[0] * cosV[2];
+
+    o.m[0][0] = cosV[1] * cosV[2];
+    o.m[1][0] = cosV[1] * sinV[2];
     o.m[2][0] = -sinV[1];
 
-    o.m[0][1] = (sinV[0] * sinV[1] * cosV[2] - cosV[0] * sinV[2]);
-    o.m[1][1] = (sinV[0] * sinV[1] * sinV[2] + cosV[0] * cosV[2]);
-    o.m[2][1] = (sinV[0] * cosV[1]);
+    o.m[0][1] = (s0_s1 * cosV[2]) - c0_s2;
+    o.m[1][1] = (s0_s1 * sinV[2]) + c0_c2;
+    o.m[2][1] = sinV[0] * cosV[1];
 
-    o.m[0][2] = (cosV[0] * cosV[2] * sinV[1] + sinV[0] * sinV[2]);
-    o.m[1][2] = (cosV[0] * sinV[2] * sinV[1] - sinV[0] * cosV[2]);
-    o.m[2][2] = (cosV[0] * cosV[1]);
+    o.m[0][2] = (c0_c2 * sinV[1]) + (sinV[0] * sinV[2]);
+    o.m[1][2] = (c0_s2 * sinV[1]) - (sinV[0] * cosV[2]);
+    o.m[2][2] = cosV[0] * cosV[1];
 
     o.m[0][3] = t.x;
     o.m[1][3] = t.y;

--- a/include/math/seadMatrixCalcCommon.hpp
+++ b/include/math/seadMatrixCalcCommon.hpp
@@ -1731,6 +1731,37 @@ void Matrix34CalcCommon<T>::getTranslation(Vec3& v, const Base& n)
 }
 
 template <typename T>
+void Matrix34CalcCommon<T>::getRotation(Vec3& v, const Base& n)
+{
+    const T a11 = n.m[0][0];
+    const T a12 = n.m[0][1];
+    const T a13 = n.m[0][2];
+
+    const T a21 = n.m[1][0];
+    const T a22 = n.m[1][1];
+    const T a23 = n.m[1][2];
+
+    const T a31 = n.m[2][0];
+    const T a32 = n.m[2][1];
+    const T a33 = n.m[2][2];
+
+    T abs = MathCalcCommon<T>::abs(a31);
+    // making sure pitch stays within bounds, setting roll to 0 otherwise
+    if ((1.0f - abs) < MathCalcCommon<T>::epsilon() * 10)
+    {
+        v.x = 0.0f;
+        v.y = (a31 / abs) * (-numbers::pi_v<T> / 2);
+        v.z = std::atan2f(-a12, -(a31 * a13));
+    }
+    else
+    {
+        v.x = std::atan2f(a32, a33);
+        v.y = std::asinf(-a31);
+        v.z = std::atan2f(a21, a11);
+    }
+}
+
+template <typename T>
 void Matrix34CalcCommon<T>::scaleAllElements(Base& n, T s)
 {
     n.m[0][0] *= s;

--- a/include/math/seadQuat.h
+++ b/include/math/seadQuat.h
@@ -65,6 +65,7 @@ public:
     bool makeVectorRotation(const Vec3& from, const Vec3& to);
     void set(T w, T x, T y, T z);
     void setRPY(T roll, T pitch, T yaw);
+    void calcRPY(Vec3& rpy) const;
 
     static const Quat unit;
 };

--- a/include/math/seadQuat.hpp
+++ b/include/math/seadQuat.hpp
@@ -85,4 +85,10 @@ inline void Quat<T>::setRPY(T roll, T pitch, T yaw)
     QuatCalcCommon<T>::setRPY(*this, roll, pitch, yaw);
 }
 
+template <typename T>
+inline void Quat<T>::calcRPY(Vec3& vec) const
+{
+    QuatCalcCommon<T>::calcRPY(vec, *this);
+}
+
 }  // namespace sead

--- a/include/math/seadQuatCalcCommon.h
+++ b/include/math/seadQuatCalcCommon.h
@@ -20,6 +20,7 @@ public:
     static bool makeVectorRotation(Base& q, const Vec3& from, const Vec3& to);
     static void set(Base& q, T w, T x, T y, T z);
     static void setRPY(Base& q, T roll, T pitch, T yaw);
+    static void calcRPY(Vec3& rpy, const Base& q);
 };
 
 }  // namespace sead


### PR DESCRIPTION
The simplest change, `fitSign`, should be pretty straight-forward. To match the sign, it has to be properly removed before added again, which was missing previously. I don't have a function to test this.

Next, Matrix34->getRotation has been added, along with a fix for `makeRT` (constructing it from Rotation and Translation).

Finally, the "problematic" change, is adding `calcRPY` to `seadQuat`. This function is not inlined in Super Mario Odyssey, so I created a playground for this mismatch: https://decomp.me/scratch/jlIf0

It seems related to creating a Matrix from `makeQT`, followed by a `getRotation`, but using a real matrix in this context is not possible, and the `makeQT`-part seems to be slightly different.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/98)
<!-- Reviewable:end -->
