### PR TITLE
math/Matrix: Add comparison operators for Matrix34

### DIFF
--- a/include/math/seadMathBase.h
+++ b/include/math/seadMathBase.h
@@ -74,7 +74,7 @@ struct BaseMtx33
     union
     {
         T m[3][3];
-        T a[9];
+        std::array<T, 9> a;
     };
 };
 
@@ -84,7 +84,7 @@ struct BaseMtx34
     union
     {
         T m[3][4];
-        T a[12];
+        std::array<T, 12> a;
     };
 };
 
@@ -94,7 +94,7 @@ struct BaseMtx44
     union
     {
         T m[4][4];
-        T a[16];
+        std::array<T, 16> a;
     };
 };
 

--- a/include/math/seadMatrix.h
+++ b/include/math/seadMatrix.h
@@ -283,6 +283,11 @@ const Matrix44<f64> Matrix44<f64>::zero;
 template <>
 const Matrix44<f64> Matrix44<f64>::ident;
 
+template <typename T>
+bool operator==(const Matrix34<T>& lhs, const Matrix34<T>& rhs);
+template <typename T>
+bool operator!=(const Matrix34<T>& lhs, const Matrix34<T>& rhs);
+
 }  // namespace sead
 
 #define SEAD_MATH_MATRIX_H_

--- a/include/math/seadMatrix.hpp
+++ b/include/math/seadMatrix.hpp
@@ -710,4 +710,16 @@ inline void Matrix44<T>::setRow(s32 row, const Vec4& v)
     Matrix44CalcCommon<T>::setRow(*this, row, v);
 }
 
+template <typename T>
+inline bool operator==(const Matrix34<T>& lhs, const Matrix34<T>& rhs)
+{
+    return lhs.a == rhs.a;
+}
+
+template <typename T>
+inline bool operator!=(const Matrix34<T>& lhs, const Matrix34<T>& rhs)
+{
+    return lhs.a != rhs.a;
+}
+
 }  // namespace sead


### PR DESCRIPTION
Only for Matrix34 at the moment, we can add it for Matrix33 and Matrix44 if we see them used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/100)
<!-- Reviewable:end -->
