### PR TITLE
`controller`: Port changes from Wii U decomp repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,23 @@ add_library(sead OBJECT
   modules/src/container/seadPtrArray.cpp
   modules/src/container/seadTreeNode.cpp
 
+  include/controller/seadAccelerometerAddon.h
+  include/controller/seadControlDevice.h
+  include/controller/seadController.h
+  include/controller/seadControllerAddon.h
+  include/controller/seadControllerBase.h
+  include/controller/seadControllerDefine.h
+  include/controller/seadControllerMgr.h
+  include/controller/seadControllerWrapper.h
+  include/controller/seadControllerWrapperBase.h
+  include/controller/seadPatternRumbleAddon.h
+  modules/src/controller/seadController.cpp
+  modules/src/controller/seadControllerBase.cpp
+  modules/src/controller/seadControllerMgr.cpp
+  modules/src/controller/seadControllerWrapper.cpp
+  modules/src/controller/seadControllerWrapperBase.cpp
+  modules/src/controller/seadPatternRumbleAddon.cpp
+
   include/devenv/seadAssertConfig.h
   include/devenv/seadEnvUtil.h
   include/devenv/seadGameConfig.h
@@ -245,6 +262,8 @@ if(SEAD_PLATFORM STREQUAL "nin")
   target_link_libraries(sead PUBLIC NintendoSDK)
 
   target_sources(sead PRIVATE
+    include/controller/nin/seadNinJoyNpadDevice.h
+
     include/filedevice/nin/seadNinAocFileDeviceNin.h
     include/filedevice/nin/seadNinContentFileDeviceNin.h
     include/filedevice/nin/seadNinFileDeviceBaseNin.h

--- a/include/controller/nin/seadNinJoyNpadDevice.h
+++ b/include/controller/nin/seadNinJoyNpadDevice.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "controller/seadControlDevice.h"
+#include "controller/seadController.h"
+#include "heap/seadHeap.h"
+
+namespace sead
+{
+// stubbed and only added methods for seadControllerMgr
+class NinJoyNpadDevice : public ControlDevice
+{
+public:
+    NinJoyNpadDevice(ControllerMgr* mgr, Heap* heap);
+
+    void calc() override;
+
+private:
+    u8 filler[0x8620];
+};
+
+}  // namespace sead

--- a/include/controller/seadAccelerometerAddon.h
+++ b/include/controller/seadAccelerometerAddon.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "controller/seadControllerAddon.h"
+#include "math/seadVector.h"
+
+namespace sead
+{
+class Controller;
+
+class AccelerometerAddon : public ControllerAddon
+{
+    SEAD_RTTI_OVERRIDE(AccelerometerAddon, ControllerAddon)
+
+public:
+    explicit AccelerometerAddon(Controller* controller)
+        : ControllerAddon(controller), mIsEnable(false), mAcceleration(0.0f, 0.0f, 0.0f)
+    {
+        mId = ControllerDefine::cAddon_Accelerometer;
+    }
+
+    ~AccelerometerAddon() override = default;
+
+    bool isEnable() const { return mIsEnable; }
+    const Vector3f& getAcceleration() const { return mAcceleration; }
+
+protected:
+    bool mIsEnable;
+    Vector3f mAcceleration;
+};
+#ifdef cafe
+static_assert(sizeof(AccelerometerAddon) == 0x24, "sead::AccelerometerAddon size mismatch");
+#endif  // cafe
+
+}  // namespace sead

--- a/include/controller/seadControlDevice.h
+++ b/include/controller/seadControlDevice.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "container/seadListImpl.h"
+#include "controller/seadControllerDefine.h"
+#include "prim/seadRuntimeTypeInfo.h"
+
+namespace sead
+{
+class ControllerMgr;
+
+class ControlDevice
+{
+    SEAD_RTTI_BASE(ControlDevice)
+
+public:
+    explicit ControlDevice(ControllerMgr* mgr) : mId(ControllerDefine::cDevice_Null), mMgr(mgr) {}
+
+    virtual ~ControlDevice() = default;
+
+    virtual void calc() = 0;
+
+    ControllerDefine::DeviceId getId() const { return mId; }
+
+protected:
+    ListNode mListNode;
+    ControllerDefine::DeviceId mId;
+    ControllerMgr* mMgr;
+
+    friend class ControllerMgr;
+};
+#ifdef cafe
+static_assert(sizeof(ControlDevice) == 0x14, "sead::ControlDevice size mismatch");
+#endif  // cafe
+
+}  // namespace sead

--- a/include/controller/seadController.h
+++ b/include/controller/seadController.h
@@ -2,38 +2,63 @@
 
 #include "container/seadOffsetList.h"
 #include "controller/seadControllerBase.h"
+#include "controller/seadControllerDefine.h"
 
 namespace sead
 {
-class ControllerMgr;
 class ControllerAddon;
-
-namespace ControllerDefine
-{
-enum AddonId : int
-{
-};
-enum ControllerId : int
-{
-    _15 = 15,
-    _16 = 16
-};
-enum DeviceId : int
-{
-};
-
-}  // namespace ControllerDefine
+class ControllerMgr;
+class ControllerWrapperBase;
 
 class Controller : public ControllerBase
 {
     SEAD_RTTI_OVERRIDE(Controller, ControllerBase)
 public:
-    Controller(ControllerMgr*);
+    enum PadIdx
+    {
+        cPadIdx_A = 0,
+        cPadIdx_B = 1,
+        cPadIdx_C = 2,
+        cPadIdx_X = 3,
+        cPadIdx_Y = 4,
+        cPadIdx_Z = 5,
+        cPadIdx_2 = 6,  // Also Right-Stick Click
+        cPadIdx_1 = 7,  // Also Left-Stick Click
+        cPadIdx_Home = 8,
+        cPadIdx_Minus = 9,
+        cPadIdx_Plus = 10,
+        cPadIdx_Start = 11,
+        cPadIdx_Select = 12,
+        cPadIdx_ZL = cPadIdx_C,
+        cPadIdx_ZR = cPadIdx_Z,
+        cPadIdx_L = 13,
+        cPadIdx_R = 14,
+        cPadIdx_Touch = 15,
+        cPadIdx_Up = 16,
+        cPadIdx_Down = 17,
+        cPadIdx_Left = 18,
+        cPadIdx_Right = 19,
+        cPadIdx_LeftStickUp = 20,
+        cPadIdx_LeftStickDown = 21,
+        cPadIdx_LeftStickLeft = 22,
+        cPadIdx_LeftStickRight = 23,
+        cPadIdx_RightStickUp = 24,
+        cPadIdx_RightStickDown = 25,
+        cPadIdx_RightStickLeft = 26,
+        cPadIdx_RightStickRight = 27,
+        cPadIdx_Max = 28
+    };
+
+    explicit Controller(ControllerMgr* mgr);
     virtual ~Controller();
+
     virtual void calc();
-    virtual bool isConnected();
-    ControllerAddon* getAddonByOrder(ControllerDefine::AddonId, int);
-    ControllerAddon* getAddon(ControllerDefine::AddonId);
+    virtual bool isConnected() const;
+    ControllerAddon* getAddonByOrder(ControllerDefine::AddonId id, int index) const;
+    ControllerAddon* getAddon(ControllerDefine::AddonId id) const;
+
+    template <typename T>
+    T getAddonAs() const;
 
 protected:
     virtual void calcImpl_() = 0;
@@ -41,10 +66,29 @@ protected:
     virtual void setIdle_();
 
 private:
-    int mControllerId;
+    ControllerDefine::ControllerId mId;
     ControllerMgr* mMgr;
-    OffsetList<ControllerAddon> mAddonList;
-    OffsetList<void*> _160;  // unknown type
+    OffsetList<ControllerAddon> mAddons;
+    OffsetList<ControllerWrapperBase> mWrappers;
+
+    friend class ControllerWrapperBase;
+    friend class ControllerMgr;
 };
+#ifdef cafe
+static_assert(sizeof(Controller) == 0x15C, "sead::Controller size mismatch");
+#endif  // cafe
+
+template <typename T>
+T Controller::getAddonAs() const
+{
+    for (auto& addon : mAddons)
+    {
+        T result = DynamicCast<std::remove_pointer<T>>(addon);
+        if (result)
+            return result;
+    }
+
+    return nullptr;
+}
 
 }  // namespace sead

--- a/include/controller/seadControllerAddon.h
+++ b/include/controller/seadControllerAddon.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "container/seadListImpl.h"
+#include "controller/seadControllerDefine.h"
+#include "prim/seadRuntimeTypeInfo.h"
+
+namespace sead
+{
+class Controller;
+
+class ControllerAddon
+{
+    SEAD_RTTI_BASE(ControllerAddon)
+
+public:
+    explicit ControllerAddon(Controller* controller)
+        : mId(ControllerDefine::cAddon_Null), mController(controller)
+    {
+    }
+
+    virtual ~ControllerAddon() = default;
+
+    virtual bool calc() = 0;
+
+protected:
+    ListNode mListNode;
+    ControllerDefine::AddonId mId;
+    Controller* mController;
+
+    friend class Controller;
+};
+#ifdef cafe
+static_assert(sizeof(ControllerAddon) == 0x14, "sead::ControllerAddon size mismatch");
+#endif  // cafe
+
+}  // namespace sead

--- a/include/controller/seadControllerDefine.h
+++ b/include/controller/seadControllerDefine.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "basis/seadTypes.h"
+
+namespace sead
+{
+// from Wii U-decomp, not adjusted to switch
+class ControllerDefine
+{
+public:
+    enum ControllerId
+    {
+        cController_Null = 0,
+        cController_Win = 1,
+        cController_Ctr = 2,
+        cController_CtrDebug = 3,
+        cController_WiiRemote = 4,
+        cController_CafeDebug = 5,
+        cController_WinDRC = 6,
+        cController_CafeRemote = 7,
+        cController_CafeDRC = 8,
+        cController_Merge = 9,
+        cController_UserDefine = 10,
+
+        _15 = 15,
+        _16 = 16
+    };
+
+    enum DeviceId
+    {
+        cDevice_Null = 0,
+        cDevice_KeyboardMouse = 1,
+        cDevice_CtrHid = 2,
+        cDevice_WinJoyPad = 3,
+        cDevice_RvlWPad = 4,
+        cDevice_WinWPad = 5,
+        cDevice_CafeDebugPad = 6,
+        cDevice_CafeWPad = 7,
+        cDevice_CafeVPad = 8,
+        cDevice_UserDefine = 9
+    };
+
+    enum AddonId
+    {
+        cAddon_Null = 0,
+        cAddon_Accelerometer = 1,
+        cAddon_PatternRumble = 2,
+        cAddon_UserDefine = 3
+    };
+};
+
+}  // namespace sead

--- a/include/controller/seadControllerMgr.h
+++ b/include/controller/seadControllerMgr.h
@@ -5,41 +5,124 @@
 #include "controller/seadController.h"
 #include "framework/seadCalculateTask.h"
 #include "framework/seadTaskMgr.h"
+#include "framework/seadTaskParameter.h"
 #include "heap/seadDisposer.h"
+#include "prim/seadRuntimeTypeInfo.h"
 
 namespace sead
 {
+class ControlDevice;
 class Controller;
-class NinJoyNpadDevice;
+class ControllerAddon;
 
 class ControllerMgr : public CalculateTask
 {
     SEAD_TASK_SINGLETON(ControllerMgr)
-public:
-    explicit ControllerMgr(const TaskConstructArg& arg);
-    ControllerMgr();
-
-    void calc() override;
-    void finalize();
-    void finalizeDefault();
-    int findControllerPort(const Controller* controller);
-    NinJoyNpadDevice* getControlDevice(ControllerDefine::DeviceId device_id);
-    // unknown return type
-    void* getControllerAddon(int, ControllerDefine::AddonId addon_id);
-    // unknown return type
-    void* getControllerAddonByOrder(int, ControllerDefine::AddonId addon_id, int);
-    Controller* getControllerByOrder(ControllerDefine::ControllerId controller_id, int);
-    // unknown return type, probably inherited from TaskBase
-    void* getFramework();
-    void initialize(int, Heap* heap);
-    void initializeDefault(Heap* heap);
-    void prepare() override;
-
-    Controller* getController(int port) { return mArray[port]; }
+    SEAD_RTTI_OVERRIDE(ControllerMgr, CalculateTask)
 
 private:
-    OffsetList<NinJoyNpadDevice> mList;
-    PtrArray<Controller> mArray;
+    class ConstructArg : public TaskConstructArg
+    {
+    public:
+        ConstructArg() : TaskConstructArg(), mHeapArray() { heap_array = &mHeapArray; }
+
+    private:
+        HeapArray mHeapArray;
+    };
+
+public:
+    struct Parameter : public TaskParameter
+    {
+        SEAD_RTTI_OVERRIDE(Parameter, TaskParameter)
+
+    public:
+        s32 controllerMax;
+        IDelegate1<ControllerMgr*>* proc;
+    };
+
+public:
+    ControllerMgr();
+    explicit ControllerMgr(const TaskConstructArg& arg);
+    ~ControllerMgr() override;
+
+    void prepare() override;
+    void calc() override;
+
+    void initialize(s32 controller_max, Heap* heap);
+    void finalize();
+
+    void initializeDefault(Heap* heap);
+    void finalizeDefault();
+
+    // TODO: Add/remove devices & controllers
+
+    Controller* getControllerByOrder(ControllerDefine::ControllerId id, s32 index) const;
+    ControlDevice* getControlDevice(ControllerDefine::DeviceId id) const;
+    ControllerAddon* getControllerAddon(s32 index, ControllerDefine::AddonId id) const;
+    ControllerAddon* getControllerAddonByOrder(s32 controller_index,
+                                               ControllerDefine::AddonId addon_id,
+                                               int addon_index) const;
+
+    template <typename T>
+    T getControllerByOrderAs(s32 index) const;
+    template <typename T>
+    T getControlDeviceAs() const;
+    template <typename T>
+    T getControllerAddonAs(s32 index) const;
+
+    s32 findControllerPort(const Controller* controller) const;
+
+    DelegateThread* getFramework() const;
+
+    Controller* getController(int port) { return mControllers[port]; }
+
+private:
+    OffsetList<ControlDevice> mDevices;
+    PtrArray<Controller> mControllers;
 };
+#ifdef cafe
+static_assert(sizeof(ControllerMgr) == 0xE8, "sead::ControllerMgr size mismatch");
+#endif  // cafe
+
+template <typename T>
+T ControllerMgr::getControllerByOrderAs(s32 index) const
+{
+    for (PtrArray<Controller>::iterator it = mControllers.begin(); it != mControllers.end(); ++it)
+    {
+        T controller = DynamicCast<std::remove_pointer<T>::type>(&(*it));
+        if (controller)
+        {
+            if (index == 0)
+                return controller;
+
+            index--;
+        }
+    }
+
+    return nullptr;
+}
+
+template <typename T>
+T ControllerMgr::getControlDeviceAs() const
+{
+    for (OffsetList<ControlDevice>::iterator it = mDevices.begin(); it != mDevices.end(); ++it)
+    {
+        T device = DynamicCast<std::remove_pointer<T>::type>(&(*it));
+        if (device)
+            return device;
+    }
+
+    return nullptr;
+}
+
+template <typename T>
+T ControllerMgr::getControllerAddonAs(s32 index) const
+{
+    Controller* controller = mControllers.at(index);
+    if (controller)
+        return controller->getAddonAs<T>();
+
+    return nullptr;
+}
 
 }  // namespace sead

--- a/include/controller/seadControllerWrapper.h
+++ b/include/controller/seadControllerWrapper.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "controller/seadControllerWrapperBase.h"
+
+namespace sead
+{
+class ControllerWrapper : public ControllerWrapperBase
+{
+    SEAD_RTTI_OVERRIDE(ControllerWrapper, ControllerWrapperBase)
+
+public:
+    static const u8 cPadConfigDefault[Controller::cPadIdx_Max];
+
+    ControllerWrapper();
+    ~ControllerWrapper() override = default;
+
+    void calc(u32 prev_hold, bool prev_pointer_on) override;
+
+    u32 createPadMaskFromControllerPadMask_(u32 controller_mask) const;
+    void setPadConfig(s32 padbit_max, const u8* pad_config, bool enable_stickcross_emulation);
+
+protected:
+    u8 mPadConfig[cPadIdx_MaxBase];
+};
+#ifdef cafe
+static_assert(sizeof(ControllerWrapper) == 0x194, "sead::ControllerWrapper size mismatch");
+#endif  // cafe
+
+}  // namespace sead

--- a/include/controller/seadControllerWrapperBase.h
+++ b/include/controller/seadControllerWrapperBase.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "controller/seadController.h"
+#include "heap/seadDisposer.h"
+#include "prim/seadRuntimeTypeInfo.h"
+
+namespace sead
+{
+class Controller;
+
+class ControllerWrapperBase : public ControllerBase, public IDisposer
+{
+    SEAD_RTTI_OVERRIDE(ControllerWrapperBase, ControllerBase)
+
+public:
+    ControllerWrapperBase();
+    virtual ~ControllerWrapperBase();
+
+    virtual void calc(u32 prev_hold, bool prev_pointer_on) = 0;
+    virtual void setIdle();
+
+protected:
+    virtual bool isIdle_();
+
+public:
+    void registerWith(Controller* controller, bool copy_repeat_setting);
+    void unregister();
+    void copyRepeatSetting(const Controller* controller);
+    void setEnable(bool enable);
+    void setEnableOtherWrappers(bool enable) const;
+
+protected:
+    Controller* mController;
+    bool mIsEnable;
+    ListNode mListNode;
+    u8 mPadConfig[cPadIdx_MaxBase];
+
+    friend class Controller;
+};
+#ifdef cafe
+static_assert(sizeof(ControllerWrapperBase) == 0x174, "sead::ControllerWrapperBase size mismatch");
+#endif  // cafe
+
+}  // namespace sead

--- a/include/controller/seadPatternRumbleAddon.h
+++ b/include/controller/seadPatternRumbleAddon.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "controller/seadControllerAddon.h"
+
+namespace sead
+{
+class PatternRumbleAddon : public ControllerAddon
+{
+    SEAD_RTTI_OVERRIDE(PatternRumbleAddon, ControllerAddon)
+
+public:
+    explicit PatternRumbleAddon(Controller* controller);
+    ~PatternRumbleAddon() override = default;
+
+    bool calc() override;
+
+protected:
+    virtual void startRumbleImpl_() = 0;
+    virtual void stopRumbleImpl_() = 0;
+
+public:
+    bool isPatternEnable() const;
+    void startPattern(const char* pattern, u32 duration);
+    void stopPattern();
+
+protected:
+    const char* mPattern;
+    u32 mPatternIdx;
+    u32 mPatternDuration;
+};
+#ifdef cafe
+static_assert(sizeof(PatternRumbleAddon) == 0x20, "sead::PatternRumbleAddon size mismatch");
+#endif  // cafe
+
+}  // namespace sead

--- a/include/framework/seadTaskBase.h
+++ b/include/framework/seadTaskBase.h
@@ -10,6 +10,7 @@
 #include <prim/seadDelegateEventSlot.h>
 #include <prim/seadNamable.h>
 #include <prim/seadRuntimeTypeInfo.h>
+#include <thread/seadDelegateThread.h>
 
 namespace sead
 {
@@ -87,6 +88,8 @@ public:
     virtual const RuntimeTypeInfo::Interface* getCorrespondingMethodTreeMgrTypeInfo() const = 0;
     virtual MethodTreeNode* getMethodTreeNode(s32 method_type) = 0;
     virtual void onDestroy();
+
+    DelegateThread* getFramework() const;  // seems to return mTaskMgr->mPrepareThread;
 
     TaskParameter* mParameter;
     BitFlag32 mInternalFlag;

--- a/include/math/seadVector.h
+++ b/include/math/seadVector.h
@@ -2,6 +2,7 @@
 
 #include <basis/seadTypes.h>
 #include <cmath>
+#include <math/seadMathCalcCommon.h>
 #include <math/seadMathPolicies.h>
 #include <math/seadVectorCalcCommon.h>
 
@@ -56,6 +57,9 @@ struct Vector2 : public Policies<T>::Vec2Base
 
     void set(const Vector2& other);
     void set(T x_, T y_);
+
+    T length() const;
+    bool isZero() const { return *this == zero; }
 
     static const Vector2 zero;
     static const Vector2 ex;
@@ -209,8 +213,11 @@ struct Vector4 : public Policies<T>::Vec4Base
     static const Vector4 ones;
 };
 
+typedef Vector2<s32> Vector2i;
 typedef Vector2<f32> Vector2f;
+typedef Vector3<s32> Vector3i;
 typedef Vector3<f32> Vector3f;
+typedef Vector4<s32> Vector4i;
 typedef Vector4<f32> Vector4f;
 
 template <>

--- a/include/math/seadVector.hpp
+++ b/include/math/seadVector.hpp
@@ -63,6 +63,12 @@ inline void Vector2<T>::set(T x_, T y_)
 }
 
 template <typename T>
+inline T Vector2<T>::length() const
+{
+    return Vector2CalcCommon<T>::length(*this);
+}
+
+template <typename T>
 inline Vector3<T>::Vector3(T x_, T y_, T z_)
 {
     Vector3CalcCommon<T>::set(*this, x_, y_, z_);

--- a/include/math/seadVectorCalcCommon.h
+++ b/include/math/seadVectorCalcCommon.h
@@ -16,6 +16,9 @@ public:
 
     static void set(Base& o, const Base& v);
     static void set(Base& v, T x, T y);
+
+    static T squaredLength(const Base& v);
+    static T length(const Base& v);
 };
 
 template <typename T>

--- a/include/math/seadVectorCalcCommon.hpp
+++ b/include/math/seadVectorCalcCommon.hpp
@@ -40,6 +40,18 @@ inline void Vector2CalcCommon<T>::set(Base& v, T x, T y)
 }
 
 template <typename T>
+inline T Vector2CalcCommon<T>::squaredLength(const Base& v)
+{
+    return v.x * v.x + v.y * v.y;
+}
+
+template <typename T>
+inline T Vector2CalcCommon<T>::length(const Base& v)
+{
+    return MathCalcCommon<T>::sqrt(squaredLength(v));
+}
+
+template <typename T>
 inline void Vector3CalcCommon<T>::add(Base& o, const Base& a, const Base& b)
 {
     o.x = a.x + b.x;

--- a/modules/src/controller/seadController.cpp
+++ b/modules/src/controller/seadController.cpp
@@ -1,0 +1,83 @@
+#include "controller/seadController.h"
+
+#include "controller/seadControllerAddon.h"
+#include "controller/seadControllerDefine.h"
+#include "controller/seadControllerMgr.h"
+#include "controller/seadControllerWrapperBase.h"
+
+namespace sead
+{
+Controller::Controller(ControllerMgr* mgr)
+    : ControllerBase(cPadIdx_Max, cPadIdx_LeftStickUp, cPadIdx_RightStickUp, cPadIdx_Touch),
+      mId(ControllerDefine::cController_Null), mMgr(mgr)
+{
+    mAddons.initOffset(offsetof(ControllerAddon, mListNode));
+    mWrappers.initOffset(offsetof(ControllerWrapperBase, mListNode));
+}
+
+Controller::~Controller() = default;
+
+void Controller::calc()
+{
+    u32 prev_hold = getHoldMask();
+    bool prev_pointer_on = isPointerOn();
+
+    calcImpl_();
+
+    updateDerivativeParams_(prev_hold, prev_pointer_on);
+
+    bool is_idle = true;
+
+    for (auto it = mAddons.begin(); it != mAddons.end(); ++it)
+    {
+        if (it->calc())
+            is_idle = false;
+    }
+
+    if (is_idle && isIdle_())
+        mIdleFrame++;
+    else
+        mIdleFrame = 0;
+
+    for (auto it = mWrappers.begin(); it != mWrappers.end(); ++it)
+        it->calc(prev_hold, prev_pointer_on);
+}
+
+bool Controller::isConnected() const
+{
+    return true;
+}
+
+ControllerAddon* Controller::getAddon(ControllerDefine::AddonId id) const
+{
+    return getAddonByOrder(id, 0);
+}
+ControllerAddon* Controller::getAddonByOrder(ControllerDefine::AddonId id, int index) const
+{
+    for (auto& addon : mAddons)
+    {
+        if (addon.mId == id)
+        {
+            if (index == 0)
+                return &addon;
+            index--;
+        }
+    }
+
+    return nullptr;
+}
+
+bool Controller::isIdle_()
+{
+    return isIdleBase_();
+}
+
+void Controller::setIdle_()
+{
+    setIdleBase_();
+
+    for (auto it = mWrappers.begin(); it != mWrappers.end(); ++it)
+        it->setIdle();
+}
+
+}  // namespace sead

--- a/modules/src/controller/seadControllerBase.cpp
+++ b/modules/src/controller/seadControllerBase.cpp
@@ -1,0 +1,287 @@
+#include "controller/seadControllerBase.h"
+
+namespace sead
+{
+const f32 ControllerBase::cStickHoldThresholdDefault = 0.5f;
+const f32 ControllerBase::cStickReleaseThresholdDefault = 0.25f;
+
+const Vector2f ControllerBase::cInvalidPointer(Mathf::minNumber(), Mathf::minNumber());
+const Vector2i ControllerBase::cInvalidPointerS32(Mathi::minNumber(), Mathi::minNumber());
+
+ControllerBase::ControllerBase(s32 padBitMax, s32 leftStickCrossStartBit,
+                               s32 rightStickCrossStartBit, s32 touchKeyBit)
+    : mPadTrig(), mPadRelease(), mPadRepeat(), mPointerFlag(), mPointerS32(cInvalidPointerS32),
+      mPointerBound(), mLeftStickHoldThreshold(0.5f), mRightStickHoldThreshold(0.5f),
+      mLeftStickReleaseThreshold(0.25f), mRightStickReleaseThreshold(0.25f), mPadBitMax(padBitMax),
+      mLeftStickCrossStartBit(leftStickCrossStartBit),
+      mRightStickCrossStartBit(rightStickCrossStartBit), mTouchKeyBit(touchKeyBit), mIdleFrame(0),
+      mPadHold(), mPointer(cInvalidPointer), mLeftStick(0.0f, 0.0f), mRightStick(0.0f, 0.0f),
+      mLeftAnalogTrigger(0.0f), mRightAnalogTrigger(0.0f)
+{
+    if (cPadIdx_MaxBase < padBitMax)
+    {
+        SEAD_ASSERT_MSG(false, "illegal padBitMax[%d]", padBitMax);
+        mPadBitMax = cPadIdx_MaxBase;
+    }
+
+    for (u32 i = 0; i < cPadIdx_MaxBase; i++)
+    {
+        mPadRepeatDelays[i] = 30;
+        mPadRepeatPulses[i] = 1;
+        mPadHoldCounts[i] = 0;
+    }
+}
+
+void ControllerBase::setPointerWithBound_(bool is_on, bool touchkey_hold, const Vector2f& pos)
+{
+    if (is_on)
+    {
+        if (!mPointerBound.isUndef())
+        {
+            if (mPointerBound.isInside(pos))
+            {
+                mPointer.x = pos.x - mPointerBound.getMin().x;
+                mPointer.y = pos.y - mPointerBound.getMin().y;
+            }
+            else
+            {
+                is_on = false;
+            }
+        }
+        else
+        {
+            mPointer.x = pos.x;
+            mPointer.y = pos.y;
+        }
+    }
+
+    mPointerFlag.change(cPointerOn, is_on);
+
+    if (mTouchKeyBit >= 0)
+    {
+        mPadHold.changeBit(mTouchKeyBit, is_on && touchkey_hold);
+    }
+
+    if (mPointerFlag.isOn(cPointerUnkFlag3))
+    {
+        if (mPointerFlag.isOff(cPointerOn))
+        {
+            mPointer.x = cInvalidPointer.x;
+            mPointer.y = cInvalidPointer.y;
+        }
+
+        mPointerFlag.reset(cPointerUnkFlag3);
+    }
+}
+
+void ControllerBase::updateDerivativeParams_(u32 prev_hold, bool prev_pointer_on)
+{
+    u32 stick_hold = 0;
+
+    if (mLeftStickCrossStartBit >= 0)
+    {
+        stick_hold |= getStickHold_(prev_hold, mLeftStick, mLeftStickHoldThreshold,
+                                    mLeftStickReleaseThreshold, mLeftStickCrossStartBit);
+    }
+
+    if (mRightStickCrossStartBit >= 0)
+    {
+        stick_hold |= getStickHold_(prev_hold, mRightStick, mRightStickHoldThreshold,
+                                    mRightStickReleaseThreshold, mRightStickCrossStartBit);
+    }
+
+    mPadHold.setDirect(mPadHold.getDirect() & ~createStickCrossMask_() | stick_hold);
+
+    mPadTrig.setDirect(~prev_hold & mPadHold.getDirect());
+    mPadRelease.setDirect(prev_hold & ~mPadHold.getDirect());
+    mPadRepeat.setDirect(0);
+
+    for (s32 i = 0; i < mPadBitMax; i++)
+    {
+        if (mPadHold.isOnBit(i))
+        {
+            if (mPadRepeatPulses[i])
+            {
+                if (mPadHoldCounts[i] == mPadRepeatDelays[i])
+                    mPadRepeat.setBit(i);
+
+                else if (mPadRepeatDelays[i] < mPadHoldCounts[i] &&
+                         (mPadHoldCounts[i] - mPadRepeatDelays[i]) % mPadRepeatPulses[i] == 0)
+                {
+                    mPadRepeat.setBit(i);
+                }
+            }
+
+            mPadHoldCounts[i]++;
+        }
+        else
+        {
+            mPadHoldCounts[i] = 0;
+        }
+    }
+
+    mPointerFlag.change(cPointerOnNow, !prev_pointer_on && mPointerFlag.isOn(cPointerOn));
+    mPointerFlag.change(cPointerOffNow, prev_pointer_on && mPointerFlag.isOff(cPointerOn));
+
+    mPointerS32.x = (s32)mPointer.x;
+    mPointerS32.y = (s32)mPointer.y;
+}
+
+u32 ControllerBase::getPadHoldCount(s32 bit) const
+{
+    SEAD_ASSERT(bit < mPadBitMax);
+    return mPadHoldCounts[bit];
+}
+
+void ControllerBase::setPadRepeat(u32 mask, u8 delay_frame, u8 pulse_frame)
+{
+    BitFlag32 pad_to_set(mask);
+
+    for (s32 i = 0; i < mPadBitMax; i++)
+    {
+        if (pad_to_set.isOnBit(i))
+        {
+            mPadRepeatDelays[i] = delay_frame;
+            mPadRepeatPulses[i] = pulse_frame;
+        }
+    }
+}
+
+void ControllerBase::setLeftStickCrossThreshold(f32 hold, f32 release)
+{
+    if (hold >= release)
+    {
+        mLeftStickHoldThreshold = hold;
+        mLeftStickReleaseThreshold = release;
+    }
+    else
+    {
+        SEAD_ASSERT_MSG(false, "hold[%f] must be larger than or equal to release[%f].", hold,
+                        release);
+    }
+}
+
+void ControllerBase::setRightStickCrossThreshold(f32 hold, f32 release)
+{
+    if (hold >= release)
+    {
+        mRightStickHoldThreshold = hold;
+        mRightStickReleaseThreshold = release;
+    }
+    else
+    {
+        SEAD_ASSERT_MSG(false, "hold[%f] must be larger than or equal to release[%f].", hold,
+                        release);
+    }
+}
+
+void ControllerBase::setPointerBound(const BoundBox2f& bound)
+{
+    mPointerBound.set(bound.getMin(), bound.getMax());
+    mPointerFlag.set(cPointerUnkFlag3);
+}
+
+u32 ControllerBase::getStickHold_(u32 prev_hold, const Vector2f& stick, f32 hold_threshold,
+                                  f32 release_threshold, s32 start_bit)
+{
+    f32 length = stick.length();
+
+    if (length < release_threshold ||
+        (length < hold_threshold &&
+         (prev_hold & (1 << start_bit + cCrossUp | 1 << start_bit + cCrossDown |
+                       1 << start_bit + cCrossLeft | 1 << start_bit + cCrossRight)) == 0))
+    {
+        return 0;
+    }
+    else
+    {
+        u32 angle = Mathf::atan2Idx(stick.y, stick.x);
+
+        if (angle < 0x10000000)
+        {
+            return 1 << start_bit + cCrossRight;
+        }
+        else if (angle < 0x30000000)
+        {
+            return 1 << start_bit + cCrossRight | 1 << start_bit + cCrossUp;
+        }
+        else if (angle < 0x50000000)
+        {
+            return 1 << start_bit + cCrossUp;
+        }
+        else if (angle < 0x70000000)
+        {
+            return 1 << start_bit + cCrossLeft | 1 << start_bit + cCrossUp;
+        }
+        else if (angle < 0x90000000)
+        {
+            return 1 << start_bit + cCrossLeft;
+        }
+        else if (angle < 0xb0000000)
+        {
+            return 1 << start_bit + cCrossLeft | 1 << start_bit + cCrossDown;
+        }
+        else if (angle < 0xd0000000)
+        {
+            return 1 << start_bit + cCrossDown;
+        }
+        else if (angle < 0xf0000000)
+        {
+            return 1 << start_bit + cCrossRight | 1 << start_bit + cCrossDown;
+        }
+        else
+        {
+            return 1 << start_bit + cCrossRight;
+        }
+    }
+}
+
+bool ControllerBase::isIdleBase_()
+{
+    return getHoldMask() == 0 && mPointerFlag.isOff(1) && mLeftStick.isZero() &&
+           mRightStick.isZero() && mLeftAnalogTrigger == 0.0f && mRightAnalogTrigger == 0.0f;
+}
+
+void ControllerBase::setIdleBase_()
+{
+    mPadHold.makeAllZero();
+    mPadTrig.makeAllZero();
+    mPadRelease.makeAllZero();
+    mPadRepeat.makeAllZero();
+    mPointerFlag.makeAllZero();
+
+    for (s32 i = 0; i < mPadBitMax; i++)
+        mPadHoldCounts[i] = 0;
+
+    mPointer.set(cInvalidPointer);
+    mPointerS32.set(cInvalidPointerS32);
+    mLeftStick.set(0.0f, 0.0f);
+    mRightStick.set(0.0f, 0.0f);
+    mLeftAnalogTrigger = 0.0f;
+    mRightAnalogTrigger = 0.0f;
+}
+
+u32 ControllerBase::createStickCrossMask_()
+{
+    BitFlag32 mask;
+
+    if (mLeftStickCrossStartBit >= 0)
+    {
+        mask.setBit(mLeftStickCrossStartBit + cCrossUp);
+        mask.setBit(mLeftStickCrossStartBit + cCrossDown);
+        mask.setBit(mLeftStickCrossStartBit + cCrossLeft);
+        mask.setBit(mLeftStickCrossStartBit + cCrossRight);
+    }
+
+    if (mRightStickCrossStartBit >= 0)
+    {
+        mask.setBit(mRightStickCrossStartBit + cCrossUp);
+        mask.setBit(mRightStickCrossStartBit + cCrossDown);
+        mask.setBit(mRightStickCrossStartBit + cCrossLeft);
+        mask.setBit(mRightStickCrossStartBit + cCrossRight);
+    }
+
+    return mask.getDirect();
+}
+
+}  // namespace sead

--- a/modules/src/controller/seadControllerMgr.cpp
+++ b/modules/src/controller/seadControllerMgr.cpp
@@ -1,0 +1,165 @@
+#include "controller/seadControllerMgr.h"
+#include "basis/seadNew.h"
+#include "controller/nin/seadNinJoyNpadDevice.h"
+#include "controller/seadControlDevice.h"
+#include "framework/seadTaskID.h"
+#include "prim/seadDelegate.h"
+#include "thread/seadDelegateThread.h"
+
+namespace sead
+{
+SEAD_TASK_SINGLETON_IMPL(ControllerMgr)
+
+// NON_MATCHING: storing too much 00s into stack (for ConstructArg)
+ControllerMgr::ControllerMgr() : CalculateTask(ConstructArg(), "sead::ControllerMgr")
+{
+    mDevices.initOffset(offsetof(ControlDevice, mListNode));
+}
+
+ControllerMgr::ControllerMgr(const TaskConstructArg& arg)
+    : CalculateTask(arg, "sead::ControllerMgr")
+{
+    mDevices.initOffset(offsetof(ControlDevice, mListNode));
+}
+
+ControllerMgr::~ControllerMgr() = default;
+
+void ControllerMgr::prepare()
+{
+    auto* parameter = DynamicCast<Parameter>(mParameter);
+    if (parameter)
+    {
+        initialize(parameter->controllerMax, nullptr);
+        if (parameter->proc)
+            parameter->proc->invoke(this);
+    }
+    else
+    {
+        initializeDefault(nullptr);
+    }
+}
+
+void ControllerMgr::initialize(s32 controller_max, Heap* heap)
+{
+    mControllers.allocBuffer(controller_max, heap);
+}
+
+void ControllerMgr::finalize()
+{
+    mControllers.freeBuffer();
+}
+
+void ControllerMgr::initializeDefault(Heap* heap)
+{
+    s32 controller_max;
+#ifdef cafe
+    controller_max = 6;
+#elif defined(NNSDK)
+    controller_max = 16;
+#else
+#error "Unknown Platform"
+#endif
+    initialize(controller_max, heap);
+
+#ifdef NNSDK
+    mDevices.pushBack(new (heap) NinJoyNpadDevice(this, heap));
+#endif
+}
+
+void ControllerMgr::finalizeDefault()
+{
+#ifdef NNSDK
+    // NON_MATCHING: missing cbz instruction within loop
+    for (auto& device : mDevices)
+    {
+        if (device.getId() == 13)
+        {
+            mDevices.erase(&device);
+            delete &device;
+            break;
+        }
+    }
+#endif  // cafe
+
+    finalize();
+}
+
+// NON_MATCHING: swapped ldr / ldrsw on second loop check
+void ControllerMgr::calc()
+{
+    for (auto it = mDevices.begin(); it != mDevices.end(); ++it)
+        it->calc();
+
+    for (auto it = mControllers.begin(); it != mControllers.end(); ++it)
+        it->calc();
+}
+
+Controller* ControllerMgr::getControllerByOrder(ControllerDefine::ControllerId id, s32 index) const
+{
+    for (auto& controller : mControllers)
+    {
+        if (controller.mId == id)
+        {
+            if (index == 0)
+                return &controller;
+
+            index--;
+        }
+    }
+
+    return nullptr;
+}
+
+ControlDevice* ControllerMgr::getControlDevice(ControllerDefine::DeviceId id) const
+{
+    for (auto& device : mDevices)
+    {
+        if (device.mId == id)
+            return &device;
+    }
+
+    return nullptr;
+}
+
+ControllerAddon* ControllerMgr::getControllerAddon(s32 index, ControllerDefine::AddonId id) const
+{
+    Controller* controller = mControllers.at(index);
+    if (controller)
+        return controller->getAddon(id);
+
+    return nullptr;
+}
+
+ControllerAddon* ControllerMgr::getControllerAddonByOrder(s32 controller_index,
+                                                          ControllerDefine::AddonId id,
+                                                          s32 addon_index) const
+{
+    Controller* controller = mControllers.at(controller_index);
+    if (controller)
+        return controller->getAddonByOrder(id, addon_index);
+
+    return nullptr;
+}
+
+s32 ControllerMgr::findControllerPort(const Controller* controller) const
+{
+    SEAD_ASSERT(controller);
+
+    s32 i = 0;
+    for (auto& controller_it : mControllers)
+    {
+        if (&controller_it == controller)
+            return i;
+        i++;
+    }
+    return -1;
+}
+
+DelegateThread* ControllerMgr::getFramework() const
+{
+    if (mTaskMgr)
+        return mTaskMgr->mPrepareThread;
+    return nullptr;
+}
+
+}  // namespace sead

--- a/modules/src/controller/seadControllerWrapper.cpp
+++ b/modules/src/controller/seadControllerWrapper.cpp
@@ -1,0 +1,123 @@
+#include "controller/seadControllerWrapper.h"
+
+#include "prim/seadMemUtil.h"
+
+namespace sead
+{
+const u8 ControllerWrapper::cPadConfigDefault[Controller::cPadIdx_Max] = {
+    Controller::cPadIdx_A,
+    Controller::cPadIdx_B,
+    Controller::cPadIdx_C,
+    Controller::cPadIdx_X,
+    Controller::cPadIdx_Y,
+    Controller::cPadIdx_Z,
+    Controller::cPadIdx_2,
+    Controller::cPadIdx_1,
+    Controller::cPadIdx_Home,
+    Controller::cPadIdx_Minus,
+    Controller::cPadIdx_Plus,
+    Controller::cPadIdx_Start,
+    Controller::cPadIdx_Select,
+    Controller::cPadIdx_L,
+    Controller::cPadIdx_R,
+    Controller::cPadIdx_Touch,
+    Controller::cPadIdx_Up,
+    Controller::cPadIdx_Down,
+    Controller::cPadIdx_Left,
+    Controller::cPadIdx_Right,
+    Controller::cPadIdx_LeftStickUp,
+    Controller::cPadIdx_LeftStickDown,
+    Controller::cPadIdx_LeftStickLeft,
+    Controller::cPadIdx_LeftStickRight,
+    Controller::cPadIdx_RightStickUp,
+    Controller::cPadIdx_RightStickDown,
+    Controller::cPadIdx_RightStickLeft,
+    Controller::cPadIdx_RightStickRight};
+
+ControllerWrapper::ControllerWrapper()
+{
+    MemUtil::copy(mPadConfig, cPadConfigDefault, Controller::cPadIdx_Max);
+}
+
+void ControllerWrapper::calc(u32 prev_hold, bool prev_pointer_on)
+{
+    if (mIsEnable && mController && mController->isConnected())
+    {
+        mPadHold = BitFlag32(createPadMaskFromControllerPadMask_(mController->getHoldMask()));
+
+        mLeftStick.set(mController->getLeftStick());
+        mRightStick.set(mController->getRightStick());
+        mLeftAnalogTrigger = mController->getLeftAnalogTrigger();
+        mRightAnalogTrigger = mController->getRightAnalogTrigger();
+
+        bool pointer_on = mController->isPointerOn();
+
+        bool touchkey_hold = false;
+        if (mTouchKeyBit >= 0)
+            touchkey_hold = mPadHold.isOnBit(mTouchKeyBit);
+
+        setPointerWithBound_(pointer_on, touchkey_hold, mController->getPointer());
+        updateDerivativeParams_(createPadMaskFromControllerPadMask_(prev_hold), prev_pointer_on);
+    }
+    else
+    {
+        setIdle();
+    }
+
+    if (isIdle_())
+        mIdleFrame++;
+    else
+        mIdleFrame = 0;
+}
+
+void ControllerWrapper::setPadConfig(s32 padbit_max, const u8* pad_config,
+                                     bool enable_stickcross_emulation)
+{
+    if (padbit_max > 32)
+        return;
+    mPadBitMax = padbit_max;
+
+    MemUtil::copy(mPadConfig, pad_config, padbit_max);
+
+    mLeftStickCrossStartBit = -1;
+    mRightStickCrossStartBit = -1;
+
+    if (enable_stickcross_emulation)
+    {
+        for (s32 i = 0; i < padbit_max; i++)
+        {
+            if (pad_config[i] == Controller::cPadIdx_LeftStickUp)
+                mLeftStickCrossStartBit = i;
+
+            else if (pad_config[i] == Controller::cPadIdx_RightStickUp)
+                mRightStickCrossStartBit = i;
+        }
+    }
+
+    mTouchKeyBit = -1;
+
+    for (s32 i = 0; i < padbit_max; i++)
+    {
+        if (pad_config[i] == Controller::cPadIdx_Touch)
+        {
+            mTouchKeyBit = i;
+            break;
+        }
+    }
+}
+
+u32 ControllerWrapper::createPadMaskFromControllerPadMask_(u32 controller_mask) const
+{
+    BitFlag32 controller_pad_mask(controller_mask);
+    BitFlag32 pad_mask;
+
+    for (int i = 0; i < mPadBitMax; i++)
+    {
+        if (controller_pad_mask.isOnBit(mPadConfig[i]))
+            pad_mask.setBit(i);
+    }
+
+    return pad_mask.getDirect();
+}
+
+}  // namespace sead

--- a/modules/src/controller/seadControllerWrapperBase.cpp
+++ b/modules/src/controller/seadControllerWrapperBase.cpp
@@ -1,0 +1,75 @@
+#include "controller/seadControllerWrapperBase.h"
+
+#include "prim/seadMemUtil.h"
+
+namespace sead
+{
+ControllerWrapperBase::ControllerWrapperBase()
+    : ControllerBase(Controller::cPadIdx_Max, -1, -1, Controller::cPadIdx_Touch),
+      mController(nullptr), mIsEnable(true)
+{
+}
+
+ControllerWrapperBase::~ControllerWrapperBase()
+{
+    unregister();
+}
+
+void ControllerWrapperBase::registerWith(Controller* controller, bool copy_repeat_setting)
+{
+    SEAD_ASSERT(controller);
+
+    unregister();
+
+    controller->mWrappers.pushBack(this);
+    mController = controller;
+
+    if (copy_repeat_setting)
+        copyRepeatSetting(controller);
+}
+
+void ControllerWrapperBase::unregister()
+{
+    if (mController)
+    {
+        mController->mWrappers.erase(this);
+        mController = nullptr;
+    }
+}
+
+void ControllerWrapperBase::copyRepeatSetting(const Controller* controller)
+{
+    MemUtil::copy(mPadRepeatDelays, controller->mPadRepeatDelays, 32);
+    MemUtil::copy(mPadRepeatPulses, controller->mPadRepeatPulses, 32);
+}
+
+void ControllerWrapperBase::setEnable(bool enable)
+{
+    mIsEnable = enable;
+}
+
+void ControllerWrapperBase::setEnableOtherWrappers(bool enable) const
+{
+    if (!mController)
+        return;
+
+    OffsetList<ControllerWrapperBase>& wrappers = mController->mWrappers;
+    for (auto it = wrappers.begin(); it != wrappers.end(); ++it)
+    {
+        ControllerWrapperBase& wrapper = *it;
+        if (&wrapper != this)
+            wrapper.setEnable(enable);
+    }
+}
+
+void ControllerWrapperBase::setIdle()
+{
+    setIdleBase_();
+}
+
+bool ControllerWrapperBase::isIdle_()
+{
+    return isIdleBase_();
+}
+
+}  // namespace sead

--- a/modules/src/controller/seadPatternRumbleAddon.cpp
+++ b/modules/src/controller/seadPatternRumbleAddon.cpp
@@ -1,0 +1,77 @@
+#include "controller/seadPatternRumbleAddon.h"
+
+#include "basis/seadRawPrint.h"
+
+// unchecked copy from Wii U-decomp
+namespace sead
+{
+PatternRumbleAddon::PatternRumbleAddon(Controller* controller)
+    : ControllerAddon(controller), mPattern(nullptr), mPatternIdx(0), mPatternDuration(0)
+{
+    mId = ControllerDefine::cAddon_PatternRumble;
+}
+
+bool PatternRumbleAddon::isPatternEnable() const
+{
+    return mPattern != nullptr;
+}
+
+void PatternRumbleAddon::startPattern(const char* pattern, u32 duration)
+{
+    SEAD_ASSERT(pattern != nullptr);
+
+    mPattern = pattern;
+    mPatternIdx = 0;
+    mPatternDuration = duration;
+}
+
+void PatternRumbleAddon::stopPattern()
+{
+    mPattern = nullptr;
+    mPatternIdx = 1;
+    mPatternDuration = 0;
+}
+
+bool PatternRumbleAddon::calc()
+{
+    if (mPattern)
+    {
+        if (mPattern[mPatternIdx] == '\0')
+        {
+            mPatternIdx = 0;
+
+            if (mPatternDuration)
+            {
+                if (mPatternDuration == 1)
+                {
+                    mPattern = nullptr;
+                    mPatternDuration = 0;
+                    stopRumbleImpl_();
+                    return false;
+                }
+
+                mPatternDuration--;
+            }
+        }
+
+        if (mPattern[mPatternIdx] == '*')
+            startRumbleImpl_();
+
+        else
+            stopRumbleImpl_();
+
+        mPatternIdx++;
+    }
+    else
+    {
+        if (mPatternIdx)
+        {
+            stopRumbleImpl_();
+            mPatternIdx = 0;
+        }
+    }
+
+    return false;
+}
+
+}  // namespace sead


### PR DESCRIPTION
This PR adds all files from the recent changes regarding controller stuff from the Wii U decomp repo. All functions are either matching or have been commented as being a mismatch.

In that route, I discovered that `TaskBase` seems to have another function, which is missing so far. As it really exists as a function and is not inlined in Super Mario Odyssey, the definition has to be added to a `cpp` later (when other functions are being implemented), so I just annotated what it should return for the moment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/102)
<!-- Reviewable:end -->
