### PR TITLE
heap: Implement seadHeapMgr and seadArena

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ add_library(sead OBJECT
   include/heap/seadHeap.h
   include/heap/seadHeapMgr.h
   include/heap/seadMemBlock.h
+  modules/src/heap/seadArena.cpp
   modules/src/heap/seadDisposer.cpp
   modules/src/heap/seadExpHeap.cpp
   modules/src/heap/seadHeap.cpp

--- a/include/heap/seadArena.h
+++ b/include/heap/seadArena.h
@@ -11,11 +11,12 @@ public:
     Arena();
     ~Arena();
 
-    u8* initialize(size_t size);
+    void initialize(size_t size);
+    void destroy();
 
-    u8* mStart;
-    size_t mSize;
-    bool mInitWithStartAddress;
+    u8* mStart = nullptr;
+    size_t mSize = 0;
+    bool mInitWithStartAddress = false;
 };
 
 }  // namespace sead

--- a/include/heap/seadHeap.h
+++ b/include/heap/seadHeap.h
@@ -65,6 +65,7 @@ public:
 
     virtual void dump() const {}
     virtual void dumpYAML(WriteStream& stream, int) const;
+    void dumpTreeYAML(WriteStream& stream, int) const;
 
 #ifdef SEAD_DEBUG
     void listenPropertyEvent(const hostio::PropertyEvent* event) override;

--- a/modules/src/heap/seadArena.cpp
+++ b/modules/src/heap/seadArena.cpp
@@ -1,0 +1,28 @@
+#include <heap/seadArena.h>
+#include <nn/os.h>
+
+namespace sead
+{
+Arena::Arena() = default;
+Arena::~Arena() = default;
+
+void Arena::initialize(size_t size)
+{
+    nn::os::AllocateMemoryBlock(reinterpret_cast<uintptr_t*>(&mStart),
+                                (size + 0x1FFFFF) & 0xFFFFFFFFFFE00000LL);
+    mSize = size;
+}
+
+void Arena::destroy()
+{
+    if (!mInitWithStartAddress)
+    {
+        nn::os::FreeMemoryBlock(reinterpret_cast<uintptr_t>(mStart),
+                                (mSize + 0x1FFFFF) & 0xFFFFFFFFFFE00000LL);
+    }
+    mInitWithStartAddress = false;
+    mStart = nullptr;
+    mSize = 0;
+}
+
+}  // namespace sead

--- a/modules/src/heap/seadHeapMgr.cpp
+++ b/modules/src/heap/seadHeapMgr.cpp
@@ -1,9 +1,14 @@
+#include <heap/seadExpHeap.h>
 #include <heap/seadHeap.h>
 #include <heap/seadHeapMgr.h>
+#include <prim/seadScopedLock.h>
+#include <thread/seadThread.h>
+#include <time/seadTickSpan.h>
+#include <utility>
 
 namespace sead
 {
-HeapMgr* HeapMgr::sInstancePtr = NULL;
+HeapMgr* HeapMgr::sInstancePtr = nullptr;
 
 HeapMgr HeapMgr::sInstance;
 Arena HeapMgr::sDefaultArena;
@@ -11,36 +16,174 @@ HeapMgr::RootHeaps HeapMgr::sRootHeaps;
 HeapMgr::IndependentHeaps HeapMgr::sIndependentHeaps;
 CriticalSection HeapMgr::sHeapTreeLockCS;
 
-HeapMgr::HeapMgr() : mAllocFailedCallback(NULL) {}
+HeapMgr::HeapMgr() = default;
 
-Heap* HeapMgr::findContainHeap(const void* ptr) const
+void HeapMgr::initialize(size_t size)
 {
-    Heap* containHeap;
-
     sHeapTreeLockCS.lock();
-
-    for (Heap& heap : sRootHeaps)
-    {
-        containHeap = heap.findContainHeap_(ptr);
-        if (containHeap != NULL)
-        {
-            sHeapTreeLockCS.unlock();
-            return containHeap;
-        }
-    }
-
-    for (Heap& heap : sIndependentHeaps)
-    {
-        containHeap = heap.findContainHeap_(ptr);
-        if (containHeap != NULL)
-        {
-            sHeapTreeLockCS.unlock();
-            return containHeap;
-        }
-    }
-
+    sArena = &sDefaultArena;
+    sDefaultArena.initialize(size);
+    initializeImpl_();
     sHeapTreeLockCS.unlock();
-    return NULL;
+}
+
+void HeapMgr::initializeImpl_()
+{
+    sInstance.mAllocFailedCallback = nullptr;
+    sSleepSpanAtRemoveCacheFailure = TickSpan::makeFromMicroSeconds(10);
+    createRootHeap_();
+    sInstancePtr = &sInstance;
+}
+
+void HeapMgr::initialize(Arena* arena)
+{
+    sArena = arena;
+    initializeImpl_();
+}
+
+void HeapMgr::createRootHeap_()
+{
+    auto* expHeap = ExpHeap::tryCreate(sArena->mStart, sArena->mSize, "RootHeap", false);
+    sRootHeaps.pushBack(expHeap);
+}
+
+// NON_MATCHING: mismatching on the loops, maybe due to an issue in popBack
+void HeapMgr::destroy()
+{
+    sHeapTreeLockCS.lock();
+    sInstance.mAllocFailedCallback = nullptr;
+
+    while (!sIndependentHeaps.isEmpty())
+    {
+        sIndependentHeaps.back()->destroy();
+        sIndependentHeaps.popBack();
+    }
+
+    while (!sRootHeaps.isEmpty())
+    {
+        sRootHeaps.back()->destroy();
+        sRootHeaps.popBack();
+    }
+
+    sInstancePtr = nullptr;
+    sArena->destroy();
+    sArena = nullptr;
+    sHeapTreeLockCS.unlock();
+}
+
+void HeapMgr::initHostIO() {}
+
+bool HeapMgr::isContainedInAnyHeap(const void* ptr)
+{
+    for (auto& heap : sRootHeaps)
+    {
+        if (heap.isInclude(ptr))
+            return true;
+    }
+    for (auto& heap : sIndependentHeaps)
+    {
+        if (heap.isInclude(ptr))
+            return true;
+    }
+    return false;
+}
+void HeapMgr::dumpTreeYAML(WriteStream& stream)
+{
+    sHeapTreeLockCS.lock();
+    for (auto& heap : sRootHeaps)
+    {
+        heap.dumpTreeYAML(stream, 0);
+    }
+    for (auto& heap : sIndependentHeaps)
+    {
+        heap.dumpTreeYAML(stream, 0);
+    }
+    sHeapTreeLockCS.unlock();
+}
+
+void HeapMgr::setAllocFromNotSeadThreadHeap(Heap* heap)
+{
+    mAllocFromNotSeadThreadHeap = heap;
+}
+
+void HeapMgr::removeFromFindContainHeapCache_(Heap* heap)
+{
+    auto* threadMgr = ThreadMgr::instance();
+    if (!threadMgr)
+        return;
+
+    Thread* mainThread = threadMgr->getMainThread();
+    if (mainThread)
+    {
+        while (!mainThread->getFindContainHeapCache()->tryRemoveHeap(heap))
+            Thread::sleep(sSleepSpanAtRemoveCacheFailure);
+    }
+
+    while (threadMgr->tryRemoveFromFindContainHeapCache(heap))
+        Thread::sleep(sSleepSpanAtRemoveCacheFailure);
+}
+
+Heap* HeapMgr::findHeapByName(const sead::SafeString& name, int index) const
+{
+    auto lock = makeScopedLock(sHeapTreeLockCS);
+    for (auto& heap : sRootHeaps)
+    {
+        Heap* found = findHeapByName_(&heap, name, &index);
+        if (found)
+            return found;
+    }
+    for (auto& heap : sIndependentHeaps)
+    {
+        Heap* found = findHeapByName_(&heap, name, &index);
+        if (found)
+            return found;
+    }
+    return nullptr;
+}
+
+Heap* HeapMgr::findHeapByName_(Heap* heap, const SafeString& name, int* index)
+{
+    if (heap->getName() == name)
+    {
+        if (*index == 0)
+            return heap;
+        --*index;
+    }
+    for (auto& child : heap->mChildren)
+    {
+        Heap* found = findHeapByName_(&child, name, index);
+        if (found)
+            return found;
+    }
+    return nullptr;
+}
+
+Heap* HeapMgr::getCurrentHeap() const
+{
+    Thread* currentThread = ThreadMgr::instance()->getCurrentThread();
+    if (currentThread)
+        return currentThread->getCurrentHeap();
+    return mAllocFromNotSeadThreadHeap;
+}
+
+Heap* HeapMgr::setCurrentHeap_(Heap* heap)
+{
+    return ThreadMgr::instance()->getCurrentThread()->setCurrentHeap(heap);
+}
+
+void HeapMgr::removeRootHeap(Heap* heap)
+{
+    if (sRootHeaps.size() < 1)
+        return;
+    s32 index = sRootHeaps.indexOf(heap);
+    if (index != -1)
+        sRootHeaps.erase(index);
+}
+
+HeapMgr::IAllocFailedCallback*
+HeapMgr::setAllocFailedCallback(HeapMgr::IAllocFailedCallback* callback)
+{
+    return std::exchange(mAllocFailedCallback, callback);
 }
 
 FindContainHeapCache::FindContainHeapCache() = default;


### PR DESCRIPTION
Two `NON_MATCHING`s on this one:
1. `HeapMgr::destroy` cleans up two static variables and destroys all heaps from the lists. However, I can't find the right iterator for this one, so I just listed all three versions I tried there. (https://decomp.me/scratch/saxAV)
2. `HeapMgr::findContainHeap` looks a bit too lengthy overall - especially looking at the CriticalSection-mutex. (https://decomp.me/scratch/QPDI8)

Apart from that, I added a few functions to `FindContainHeapCache`, which partly seem useless to me - but I can't keep up the match level with fewer functions, as I don't know enough about how Atomics are used here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/105)
<!-- Reviewable:end -->
