### PR TITLE
prim/ScopedLock: Fix makeScopedLock for pre-C++17 builds

### DIFF
--- a/include/prim/seadScopedLock.h
+++ b/include/prim/seadScopedLock.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 namespace sead
 {
 template <typename T>
@@ -7,18 +9,36 @@ class ScopedLock
 {
 public:
     explicit ScopedLock(T* lock) : mLocked(lock) { mLocked->lock(); }
+
     ScopedLock(const ScopedLock& other) = delete;
-    const ScopedLock& operator=(const ScopedLock& other) = delete;
-    virtual ~ScopedLock() { mLocked->unlock(); }
+    ScopedLock& operator=(const ScopedLock& other) = delete;
+
+    ScopedLock(ScopedLock&& other) noexcept { *this = std::move(other); }
+    ScopedLock& operator=(ScopedLock&& other) noexcept
+    {
+        if (this == &other)
+            return *this;
+
+        mLocked = other.mLocked;
+        mEngaged = std::exchange(other.mEngaged, false);
+        return *this;
+    }
+
+    virtual ~ScopedLock()
+    {
+        if (mEngaged)
+            mLocked->unlock();
+    }
 
 protected:
+    bool mEngaged = true;
     T* mLocked;
 };
 
 template <typename T>
 [[nodiscard]] inline ScopedLock<T> makeScopedLock(T& lock)
 {
-    return ScopedLock<T>(&lock);
+    return ScopedLock<T>{&lock};
 }
 
 template <typename T>
@@ -32,15 +52,29 @@ public:
         mLocked = lock;
         mLocked->lock();
     }
+
     ConditionalScopedLock(const ConditionalScopedLock& other) = delete;
-    const ConditionalScopedLock& operator=(const ConditionalScopedLock& other) = delete;
+    ConditionalScopedLock& operator=(const ConditionalScopedLock& other) = delete;
+
+    ConditionalScopedLock(ConditionalScopedLock&& other) noexcept { *this = std::move(other); }
+    ConditionalScopedLock& operator=(ConditionalScopedLock&& other) noexcept
+    {
+        if (this == &other)
+            return *this;
+
+        mLocked = other.mLocked;
+        mEngaged = std::exchange(other.mEngaged, false);
+        return *this;
+    }
+
     virtual ~ConditionalScopedLock()
     {
-        if (mLocked)
+        if (mEngaged && mLocked)
             mLocked->unlock();
     }
 
 protected:
+    bool mEngaged = true;
     T* mLocked = nullptr;
 };
 

--- a/include/prim/seadScopedLock.h
+++ b/include/prim/seadScopedLock.h
@@ -6,7 +6,7 @@ template <typename T>
 class ScopedLock
 {
 public:
-    ScopedLock(T* lock) : mLocked(lock) { mLocked->lock(); }
+    explicit ScopedLock(T* lock) : mLocked(lock) { mLocked->lock(); }
     ScopedLock(const ScopedLock& other) = delete;
     const ScopedLock& operator=(const ScopedLock& other) = delete;
     virtual ~ScopedLock() { mLocked->unlock(); }


### PR DESCRIPTION
See https://github.com/open-ead/sead/pull/105#pullrequestreview-1064473605

@MonsterDruide1 let me know if this fixes makeScopedLock on Clang 3.9.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/106)
<!-- Reviewable:end -->
