### PR TITLE
gfx: Implement FrameBuffer and LogicalFrameBuffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ add_library(sead OBJECT
   include/gfx/seadTexture.h
   modules/src/gfx/seadCamera.cpp
   modules/src/gfx/seadColor.cpp
+  modules/src/gfx/seadFrameBuffer.cpp
   # modules/src/gfx/seadPrimitiveRenderer.cpp
   # modules/src/gfx/seadPrimitiveRendererUtil.cpp
   modules/src/gfx/seadProjection.cpp

--- a/include/gfx/seadFrameBuffer.h
+++ b/include/gfx/seadFrameBuffer.h
@@ -72,9 +72,10 @@ public:
 
     virtual void copyToDisplayBuffer(DrawContext* draw_context,
                                      const DisplayBuffer* display_buffer) const;
-    virtual void clear(u32 clr_flag, const Color4f& color, f32 depth, u32 stencil) const = 0;
+    virtual void clear(DrawContext* draw_context, u32 clr_flag, const Color4f& color, f32 depth,
+                       u32 stencil) const = 0;
     virtual void clearMRT(DrawContext* draw_context, u32 target, const Color4f& color) const;
-    virtual void bindImpl_() const = 0;
+    virtual void bindImpl_(DrawContext* draw_context) const = 0;
 
     void bind(DrawContext* draw_context) const;
 };

--- a/modules/src/gfx/seadFrameBuffer.cpp
+++ b/modules/src/gfx/seadFrameBuffer.cpp
@@ -1,0 +1,17 @@
+#include <gfx/seadFrameBuffer.h>
+
+namespace sead
+{
+LogicalFrameBuffer::~LogicalFrameBuffer() = default;
+
+FrameBuffer::~FrameBuffer() = default;
+
+void FrameBuffer::copyToDisplayBuffer(DrawContext*, const DisplayBuffer*) const {}
+
+void FrameBuffer::clearMRT(DrawContext*, u32, const Color4f&) const {}
+
+void FrameBuffer::bind(DrawContext* draw_context) const
+{
+    bindImpl_(draw_context);
+}
+}  // namespace sead


### PR DESCRIPTION
Function `isDerive` of RTTI doesn't generate for FrameBuffer though.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/119)
<!-- Reviewable:end -->
