### PR TITLE
framework: Fix GameFrameworkNx include

### DIFF
--- a/include/framework/seadGameFrameworkNx.h
+++ b/include/framework/seadGameFrameworkNx.h
@@ -2,7 +2,7 @@
 
 #include <framework/seadGameFramework.h>
 #include <math/seadVector.h>
-#include <nvn/nvn_types.h>
+#include <nvn/nvn.h>
 #include <thread/seadThread.h>
 
 namespace sead


### PR DESCRIPTION
This was probably missed when doing the `nvn`-structure rework, as this header file is not referenced anywhere (yet).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/120)
<!-- Reviewable:end -->
