### PR TITLE
devenv: Add DebugFontMgr*Nvn

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(sead OBJECT
   include/devenv/seadGameConfig.h
   include/devenv/seadStackTrace.h
   modules/src/devenv/seadAssertConfig.cpp
+  modules/src/devenv/seadFontMgr.cpp
   modules/src/devenv/seadGameConfig.cpp
   modules/src/devenv/seadStackTrace.cpp
 

--- a/include/devenv/seadFontMgr.h
+++ b/include/devenv/seadFontMgr.h
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <gfx/seadCamera.h>
+#include <gfx/seadColor.h>
+#include <gfx/seadDrawContext.h>
+#include <gfx/seadProjection.h>
+#include <heap/seadDisposer.h>
+#include "nvn/nvn.h"
+#include "thread/seadAtomic.h"
+
+namespace sead
+{
+class UniformBlockBuffer
+{
+public:
+    void swap(u32 temp, u32 size)
+    {
+        _4 = temp;
+        if (temp + size < size)
+        {
+            u32 mod = temp % size;
+            _4 = mod;
+            _0 = mod;
+        }
+    }
+
+    u32 get_0() const { return _0; }
+
+private:
+    Atomic<u32> _0, _4;
+};
+
+// unknown contents and size
+class FontBase
+{
+public:
+    virtual ~FontBase();
+
+    virtual float getHeight() const = 0;
+    virtual float getWidth() const = 0;
+    virtual float getCharWidth(char16_t c) const = 0;
+    virtual u32 getEncoding() const = 0;
+    virtual u32 getMaxDrawNum() const = 0;
+    virtual void begin(DrawContext* ctx) const = 0;
+    virtual void end(DrawContext* ctx) const = 0;
+    virtual void print(DrawContext* ctx, const Projection& proj, const Camera& cam,
+                       const Matrix34f& mtx, const Color4f& color, const void* text,
+                       int len) const = 0;
+};
+
+class DebugFontMgrJis1Nvn : public FontBase
+{
+    SEAD_SINGLETON_DISPOSER(DebugFontMgrJis1Nvn)
+public:
+    DebugFontMgrJis1Nvn();
+    ~DebugFontMgrJis1Nvn() override;
+
+    float getHeight() const override;
+    float getWidth() const override;
+    float getCharWidth(char16_t c) const override;
+    u32 getEncoding() const override;
+    u32 getMaxDrawNum() const override;
+    void begin(DrawContext* ctx) const override;
+    void end(DrawContext* ctx) const override;
+    void print(DrawContext* ctx, const Projection& proj, const Camera& cam, const Matrix34f& mtx,
+               const Color4f& color, const void* text, int len) const override;
+
+    void initialize(Heap* heap, const char* shader_path, const char* font_path,
+                    const char* table_path, u32 unk);
+    void initializeFromBinary(Heap* heap, void* shader_binary, u64 shader_size, void* font_binary,
+                              u64 font_size, void* table_binary, u32 unk3);
+    void swapUniformBlockBuffer();
+    u32 searchCharIndexFormCharCode_(u32 code) const;
+
+private:
+    NVNprogram nvnProgram;
+    NVNtexture nvnTexture;
+    NVNtextureHandle nvnTextureHandle;
+    NVNmemoryPool pool1, pool2, pool3;
+    NVNbuffer buffer1;
+    u32 buffer1Size = 0;
+    void* fileData = nullptr;
+    NVNbuffer buffer2;
+    void* buffer2Map = nullptr;
+    UniformBlockBuffer mUniformBlockBuffer;
+    bool _530 = 0;
+};
+static_assert(sizeof(DebugFontMgrJis1Nvn) == 0x538);
+
+class DebugFontMgrNvn : public FontBase
+{
+    SEAD_SINGLETON_DISPOSER(DebugFontMgrNvn)
+public:
+    DebugFontMgrNvn();
+    ~DebugFontMgrNvn() override;
+
+    float getHeight() const override;
+    float getWidth() const override;
+    float getCharWidth(char16_t c) const override;
+    u32 getEncoding() const override;
+    u32 getMaxDrawNum() const override;
+    void begin(DrawContext* ctx) const override;
+    void end(DrawContext* ctx) const override;
+    void print(DrawContext* ctx, const Projection& proj, const Camera& cam, const Matrix34f& mtx,
+               const Color4f& color, const void* text, int len) const override;
+
+    void initialize(Heap* heap, const char* shader_path, const char* font_path, u32 unk);
+    void initializeFromBinary(Heap* heap, void* shader_binary, u64 shader_size, void* font_binary,
+                              u64 font_size, u32 unk3);
+    void swapUniformBlockBuffer();
+    u32 searchCharIndexFormCharCode_(u32 code) const;
+
+private:
+    NVNprogram nvnProgram;
+    NVNtexture nvnTexture;
+    NVNtextureHandle nvnTextureHandle;
+    NVNmemoryPool pool1, pool2, pool3;
+    NVNbuffer buffer1;
+    u32 buffer1Size = 0;
+    u32 _4e4;
+    NVNbuffer buffer2;
+    void* buffer2Map = nullptr;
+    UniformBlockBuffer mUniformBlockBuffer;
+    bool _528 = 0;
+};
+static_assert(sizeof(DebugFontMgrNvn) == 0x530);
+
+}  // namespace sead

--- a/include/gfx/seadDrawContext.h
+++ b/include/gfx/seadDrawContext.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <nn/gfx/gfx_CommandBuffer.h>
+#include <nn/gfx/gfx_Types.h>
 #include "basis/seadTypes.h"
 #include "prim/seadRuntimeTypeInfo.h"
 
@@ -12,17 +14,11 @@ public:
     DrawContext();
     virtual ~DrawContext();
 
+    nn::gfx::CommandBuffer* getCommandBuffer() { return &mCommandBuffer; }
+
 private:
-    u32 _8;
-    u32 _c;
-    u64 _10;
-    u8 _18[0xC0 - 0x18];
-    u64 _c0;
-    u64 _c8;
-    u64 _d0;
-    u64 _d8;
-    u64 _e0;
-    u64 _e8;
+    nn::gfx::CommandBuffer mCommandBuffer;
 };
+static_assert(sizeof(DrawContext) == 0xF0);
 
 }  // namespace sead

--- a/modules/src/devenv/seadFontMgr.cpp
+++ b/modules/src/devenv/seadFontMgr.cpp
@@ -1,0 +1,145 @@
+#include "devenv/seadFontMgr.h"
+#include "filedevice/seadFileDevice.h"
+#include "filedevice/seadFileDeviceMgr.h"
+#include "nvn/nvn.h"
+#include "nvn/nvn_FuncPtrInline.h"
+
+namespace sead
+{
+FontBase::~FontBase() = default;
+
+SEAD_SINGLETON_DISPOSER_IMPL(DebugFontMgrJis1Nvn)
+DebugFontMgrJis1Nvn::~DebugFontMgrJis1Nvn() = default;
+
+DebugFontMgrJis1Nvn::DebugFontMgrJis1Nvn() = default;
+
+void DebugFontMgrJis1Nvn::initialize(Heap* heap, const char* shader_path, const char* font_path,
+                                     const char* table_path, u32 unk)
+{
+    FileDevice::LoadArg load_arg = {};
+    load_arg.heap = heap;
+
+    load_arg.path = table_path;
+    void* table_binary = FileDeviceMgr::instance()->tryLoad(load_arg);
+
+    load_arg.path = font_path;
+    load_arg.alignment = 0x1000;
+    load_arg.buffer_size_alignment = 0x1000;
+    void* font_binary = FileDeviceMgr::instance()->tryLoad(load_arg);
+    u32 font_size = load_arg.read_size;
+
+    load_arg.path = shader_path;
+    void* shader_binary = FileDeviceMgr::instance()->tryLoad(load_arg);
+    u32 shader_size = load_arg.read_size;
+
+    initializeFromBinary(heap, shader_binary, shader_size, font_binary, font_size, table_binary,
+                         unk);
+}
+
+// missing initializeFromBinary
+
+void DebugFontMgrJis1Nvn::swapUniformBlockBuffer()
+{
+    mUniformBlockBuffer.swap(mUniformBlockBuffer.get_0(), buffer1Size);
+    _530 = false;
+}
+
+float DebugFontMgrJis1Nvn::getHeight() const
+{
+    return 16.0f;
+}
+float DebugFontMgrJis1Nvn::getWidth() const
+{
+    return 16.0f;
+}
+float DebugFontMgrJis1Nvn::getCharWidth(char16_t c) const
+{
+    return c < 0x7F ? 8.0f : 16.0f;
+}
+u32 DebugFontMgrJis1Nvn::getMaxDrawNum() const
+{
+    return 0x80;
+}
+
+void DebugFontMgrJis1Nvn::begin(DrawContext* ctx) const
+{
+    if (_530)
+        return;
+    nvnCommandBufferBindProgram(ctx->getCommandBuffer()->ToData()->pNvnCommandBuffer, &nvnProgram,
+                                31);
+}
+void DebugFontMgrJis1Nvn::end(DrawContext*) const {}
+
+// missing print and searchCharIndexFormCharCode_
+
+u32 DebugFontMgrJis1Nvn::getEncoding() const
+{
+    return 2;
+}
+
+SEAD_SINGLETON_DISPOSER_IMPL(DebugFontMgrNvn)
+DebugFontMgrNvn::~DebugFontMgrNvn() = default;
+
+DebugFontMgrNvn::DebugFontMgrNvn() = default;
+
+void DebugFontMgrNvn::initialize(Heap* heap, const char* shader_path, const char* font_path,
+                                 u32 unk)
+{
+    FileDevice::LoadArg load_arg = {};
+
+    load_arg.path = font_path;
+    load_arg.heap = heap;
+    load_arg.alignment = 0x1000;
+    load_arg.buffer_size_alignment = 0x1000;
+    void* font_binary = FileDeviceMgr::instance()->tryLoad(load_arg);
+    u32 font_size = load_arg.read_size;
+
+    load_arg.path = shader_path;
+    void* shader_binary = FileDeviceMgr::instance()->tryLoad(load_arg);
+    u32 shader_size = load_arg.read_size;
+
+    initializeFromBinary(heap, shader_binary, shader_size, font_binary, font_size, unk);
+}
+
+// missing initializeFromBinary
+
+void DebugFontMgrNvn::swapUniformBlockBuffer()
+{
+    mUniformBlockBuffer.swap(mUniformBlockBuffer.get_0(), buffer1Size);
+    _528 = false;
+}
+
+float DebugFontMgrNvn::getHeight() const
+{
+    return 16.0f;
+}
+float DebugFontMgrNvn::getWidth() const
+{
+    return 8.0f;
+}
+float DebugFontMgrNvn::getCharWidth(char16_t) const
+{
+    return 8.0f;
+}
+u32 DebugFontMgrNvn::getMaxDrawNum() const
+{
+    return 0x80;
+}
+
+void DebugFontMgrNvn::begin(DrawContext* ctx) const
+{
+    if (_528)
+        return;
+    nvnCommandBufferBindProgram(ctx->getCommandBuffer()->ToData()->pNvnCommandBuffer, &nvnProgram,
+                                NVN_SHADER_STAGE_ALL_GRAPHICS_BITS);
+}
+void DebugFontMgrNvn::end(DrawContext*) const {}
+
+// missing print and searchCharIndexFormCharCode_
+
+u32 DebugFontMgrNvn::getEncoding() const
+{
+    return 2;
+}
+
+}  // namespace sead


### PR DESCRIPTION
Final changes from the `SuperMarioOdysseyOnline`-repo.

Missing functions marked in the `cpp`. Along with it, some functions weren't able to match completely:
- `ctor`+`createInstance` on both - Not only a difference in `C1`/`C2`, but also some instruction ordering.
- `begin` on both - Might have something to do with the `pfnc_nvn` reference, have these been tested before?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/122)
<!-- Reviewable:end -->
