### PR TITLE
gfx: Add more functions to seadCamera

### DIFF
--- a/include/gfx/seadCamera.h
+++ b/include/gfx/seadCamera.h
@@ -1,5 +1,4 @@
-#ifndef SEAD_CAMERA_H_
-#define SEAD_CAMERA_H_
+#pragma once
 
 #include <math/seadMatrix.h>
 #include <math/seadVector.h>
@@ -7,6 +6,12 @@
 
 namespace sead
 {
+class OrthoProjection;
+class Projection;
+class Viewport;
+template <typename T>
+class Ray;
+
 class Camera
 {
     SEAD_RTTI_BASE(Camera)
@@ -15,8 +20,26 @@ public:
     Camera() = default;
     virtual ~Camera();
 
-    virtual void doUpdateMatrix(Matrix34f* mtx) const = 0;
+    virtual void doUpdateMatrix(Matrix34f* dst) const = 0;
 
+    void getWorldPosByMatrix(Vector3f* dst) const;
+    void getLookVectorByMatrix(Vector3f* dst) const;
+    void getRightVectorByMatrix(Vector3f* dst) const;
+    void getUpVectorByMatrix(Vector3f* dst) const;
+
+    void worldPosToCameraPosByMatrix(Vector3f* dst, const Vector3f& world_pos) const;
+    void cameraPosToWorldPosByMatrix(Vector3f* dst, const Vector3f& camera_pos) const;
+
+    void projectByMatrix(Vector2f* dst, const Vector3f& world_pos, const Projection& projection,
+                         const Viewport& viewport) const;
+    void unprojectRayByMatrix(Ray<Vector3f>* dst, const Vector3f& camera_pos) const;
+
+    Matrix34f& getMatrix() { return mMatrix; }
+    const Matrix34f& getMatrix() const { return mMatrix; }
+
+    void updateViewMatrix() { doUpdateMatrix(&mMatrix); }
+
+private:
     Matrix34f mMatrix = Matrix34f::ident;
 };
 
@@ -24,7 +47,11 @@ class LookAtCamera : public Camera
 {
     SEAD_RTTI_OVERRIDE(LookAtCamera, Camera)
 public:
+    LookAtCamera() = default;
     LookAtCamera(const Vector3f& pos, const Vector3f& at, const Vector3f& up);
+    ~LookAtCamera() override;
+
+    void doUpdateMatrix(Matrix34f* dst) const override;
 
     Vector3f& getPos() { return mPos; }
     Vector3f& getAt() { return mAt; }
@@ -33,13 +60,34 @@ public:
     const Vector3f& getAt() const { return mAt; }
     const Vector3f& getUp() const { return mUp; }
 
-    void doUpdateMatrix(Matrix34f* mtx) const override;
+private:
+    Vector3f mPos = {0.0f, 0.0f, 10.0f};
+    Vector3f mAt = {0.0f, 0.0f, 0.0f};
+    Vector3f mUp = {0.0f, 1.0f, 0.0f};
+};
+
+class DirectCamera : public Camera
+{
+    SEAD_RTTI_OVERRIDE(DirectCamera, Camera)
+public:
+    virtual ~DirectCamera();
+
+    void doUpdateMatrix(Matrix34f* dst) const override;
 
 private:
-    Vector3f mPos;
-    Vector3f mAt;
-    Vector3f mUp;
+    Matrix34f mMtx = Matrix34f::ident;
+};
+
+class OrthoCamera : public LookAtCamera
+{
+    SEAD_RTTI_OVERRIDE(OrthoCamera, LookAtCamera)
+public:
+    OrthoCamera();
+    OrthoCamera(const Vector2f&, float);
+    OrthoCamera(const OrthoProjection&);
+    ~OrthoCamera() override;
+
+    void setByOrthoProjection(const OrthoProjection&);
+    void setRotation(float rotation);
 };
 }  // namespace sead
-
-#endif  // SEAD_CAMERA_H_


### PR DESCRIPTION
With this, all functions about `sead::*Camera` should be defined in the headers.

Inspiration and parts of code from here:
https://github.com/CraftyBoss/SMO-Galaxy-Gravity/blob/master/include/sead/gfx/seadCamera.h

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/123)
<!-- Reviewable:end -->
