### PR TITLE
gfx: Add `seadDrawLockContext`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ add_library(sead OBJECT
   include/gfx/seadCamera.h
   include/gfx/seadColor.h
   include/gfx/seadDrawContext.h
+  include/gfx/seadDrawLockContext.h
   include/gfx/seadFrameBuffer.h
   include/gfx/seadPrimitiveRenderer.h
   include/gfx/seadPrimitiveRendererUtil.h
@@ -105,6 +106,7 @@ add_library(sead OBJECT
   include/gfx/seadTexture.h
   modules/src/gfx/seadCamera.cpp
   modules/src/gfx/seadColor.cpp
+  modules/src/gfx/seadDrawLockContext.cpp
   modules/src/gfx/seadFrameBuffer.cpp
   # modules/src/gfx/seadPrimitiveRenderer.cpp
   # modules/src/gfx/seadPrimitiveRendererUtil.cpp

--- a/include/gfx/seadDrawLockContext.h
+++ b/include/gfx/seadDrawLockContext.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "hostio/seadHostIONode.h"
+#include "thread/seadCriticalSection.h"
+
+namespace sead
+{
+class DrawLockContext : public hostio::Node
+{
+public:
+    DrawLockContext();
+
+    void initialize(Heap* heap);
+    void lock();
+    void unlock();
+    void genMessage(hostio::Context* context);
+
+private:
+    [[maybe_unused]] u32 _8 = 0;
+    CriticalSection mCriticalSection{};
+};
+
+}  // namespace sead

--- a/modules/src/gfx/seadDrawLockContext.cpp
+++ b/modules/src/gfx/seadDrawLockContext.cpp
@@ -1,0 +1,20 @@
+#include "gfx/seadDrawLockContext.h"
+
+namespace sead
+{
+DrawLockContext::DrawLockContext() = default;
+
+void DrawLockContext::initialize(Heap*) {}
+
+void DrawLockContext::lock()
+{
+    mCriticalSection.lock();
+}
+void DrawLockContext::unlock()
+{
+    mCriticalSection.unlock();
+}
+
+void DrawLockContext::genMessage(hostio::Context*) {}
+
+}  // namespace sead


### PR DESCRIPTION
Not much more to say about it. Pretty simple, all functions are matching.

Inspired by
https://github.com/CraftyBoss/SMO-Galaxy-Gravity/blob/master/include/sead/gfx/seadContext.h#L33

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/124)
<!-- Reviewable:end -->
