### PR TITLE
CalcCommon additions, minor fixes

### DIFF
--- a/include/math/seadMathCalcCommon.hpp
+++ b/include/math/seadMathCalcCommon.hpp
@@ -369,7 +369,7 @@ inline f64 MathCalcCommon<f64>::abs(f64 x)
 template <typename T>
 inline T MathCalcCommon<T>::max(T a, T b)
 {
-    return a < b ? b : a;
+    return a > b ? a : b;
 }
 
 template <typename T>

--- a/include/math/seadQuatCalcCommon.h
+++ b/include/math/seadQuatCalcCommon.h
@@ -20,6 +20,7 @@ public:
     static bool makeVectorRotation(Base& q, const Vec3& from, const Vec3& to);
     static void set(Base& q, T w, T x, T y, T z);
     static void setRPY(Base& q, T roll, T pitch, T yaw);
+    static void setAxisAngle(Base& q, const Vec3& axis, T angle);
     static void calcRPY(Vec3& rpy, const Base& q);
 };
 

--- a/include/math/seadQuatCalcCommon.hpp
+++ b/include/math/seadQuatCalcCommon.hpp
@@ -6,7 +6,6 @@
 
 #include <limits>
 #include <math/seadMathCalcCommon.h>
-#include <math/seadQuat.h>
 
 namespace sead
 {
@@ -92,7 +91,7 @@ inline void QuatCalcCommon<T>::slerpTo(Base& out, const Base& q1, const Base& q2
 template <typename T>
 inline void QuatCalcCommon<T>::makeUnit(Base& q)
 {
-    q = Quat<T>::unit;
+    q = Base::unit;
 }
 
 template <typename T>
@@ -147,6 +146,18 @@ inline void QuatCalcCommon<T>::setRPY(Base& q, T roll, T pitch, T yaw)
     const T z = (sy_cp * cr) - (cy_sp * sr);
 
     set(q, w, x, y, z);
+}
+
+template <typename T>
+inline void QuatCalcCommon<T>::setAxisAngle(Base& q, const Vec3& axis, T angle)
+{
+    T angleRad = sead::Mathf::deg2rad(angle);
+    angleRad *= 0.5f;
+    q.w = cosf(angleRad);
+    T sa = sinf(angleRad);
+    q.x = sa * axis.x;
+    q.y = sa * axis.y;
+    q.z = sa * axis.z;
 }
 
 }  // namespace sead

--- a/include/math/seadQuatCalcCommon.hpp
+++ b/include/math/seadQuatCalcCommon.hpp
@@ -151,9 +151,9 @@ inline void QuatCalcCommon<T>::setRPY(Base& q, T roll, T pitch, T yaw)
 template <typename T>
 inline void QuatCalcCommon<T>::setAxisAngle(Base& q, const Vec3& axis, T angle)
 {
-    T angleRad = sead::Mathf::deg2rad(angle);
+    T angleRad = sead::MathCalcCommon<T>::deg2rad(angle);
     angleRad *= 0.5f;
-    q.w = cosf(angleRad);
+    q.w = sead::MathCalcCommon<T>::cos(angleRad);
     T sa = sinf(angleRad);
     q.x = sa * axis.x;
     q.y = sa * axis.y;

--- a/include/math/seadQuatCalcCommon.hpp
+++ b/include/math/seadQuatCalcCommon.hpp
@@ -151,10 +151,10 @@ inline void QuatCalcCommon<T>::setRPY(Base& q, T roll, T pitch, T yaw)
 template <typename T>
 inline void QuatCalcCommon<T>::setAxisAngle(Base& q, const Vec3& axis, T angle)
 {
-    T angleRad = sead::MathCalcCommon<T>::deg2rad(angle);
+    T angleRad = MathCalcCommon<T>::deg2rad(angle);
     angleRad *= 0.5f;
-    q.w = sead::MathCalcCommon<T>::cos(angleRad);
-    T sa = sinf(angleRad);
+    q.w = MathCalcCommon<T>::cos(angleRad);
+    T sa = MathCalcCommon<T>::sin(angleRad);
     q.x = sa * axis.x;
     q.y = sa * axis.y;
     q.z = sa * axis.z;

--- a/include/math/seadVectorCalcCommon.h
+++ b/include/math/seadVectorCalcCommon.h
@@ -28,6 +28,7 @@ public:
     using Base = typename Policies<T>::Vec3Base;
     using Mtx33 = typename Policies<T>::Mtx33Base;
     using Mtx34 = typename Policies<T>::Mtx34Base;
+    using Quat = typename Policies<T>::QuatBase;
 
     static void add(Base& o, const Base& a, const Base& b);
     static void sub(Base& o, const Base& a, const Base& b);
@@ -40,6 +41,8 @@ public:
     static void rotate(Base& o, const Mtx33& m, const Base& a);
     /// Apply a rotation `m` to the vector `a`.
     static void rotate(Base& o, const Mtx34& m, const Base& a);
+    /// Apply a rotation 'q' to the vector 'a'
+    static void rotate(Base& o, const Quat& q, const Base& a);
 
     static void cross(Base& o, const Base& a, const Base& b);
     static T dot(const Base& a, const Base& b);

--- a/include/math/seadVectorCalcCommon.hpp
+++ b/include/math/seadVectorCalcCommon.hpp
@@ -5,6 +5,7 @@
 #endif  // cafe
 
 #include <math/seadMathCalcCommon.h>
+#include <math/seadQuatCalcCommon.h>
 #ifndef SEAD_MATH_VECTOR_CALC_COMMON_H_
 #include <math/seadVectorCalcCommon.h>
 #endif
@@ -120,6 +121,23 @@ inline void Vector3CalcCommon<T>::rotate(Base& o, const Mtx34& m, const Base& a)
     o.x = m.m[0][0] * tmp.x + m.m[0][1] * tmp.y + m.m[0][2] * tmp.z;
     o.y = m.m[1][0] * tmp.x + m.m[1][1] * tmp.y + m.m[1][2] * tmp.z;
     o.z = m.m[2][0] * tmp.x + m.m[2][1] * tmp.y + m.m[2][2] * tmp.z;
+}
+
+template <typename T>
+inline void Vector3CalcCommon<T>::rotate(Base& o, const Quat& q, const Base& v)
+{
+    Quat r;  // quat-multiplication with 0 on w for v
+    r.x = (q.y * v.z) - (q.z * v.y) + (q.w * v.x);
+    r.y = -(q.x * v.z) + (q.z * v.x) + (q.w * v.y);
+    r.z = (q.x * v.y) - (q.y * v.x) + (q.w * v.z);
+    r.w = -(q.x * v.x) - (q.y * v.y) - (q.z * v.z);
+
+    r.w *= -1;
+
+    // quat-multiplication
+    o.x = (q.w * r.x) - (q.z * r.y) + (q.y * r.z) + (q.x * r.w);
+    o.y = (q.z * r.x) + (q.w * r.y) - (q.x * r.z) + (q.y * r.w);
+    o.z = (q.w * r.z) + (-(q.y * r.x) + (q.x * r.y)) + (q.z * r.w);
 }
 
 template <typename T>


### PR DESCRIPTION
MathCalcCommon::max was changed due to being the exact same implementation as ::clampMin, which is unnecessary, and the new implementation was needed. QuatCalcCommon::setAxisAngle converts and axis and an angle into a quaternion, and a new Vector3CalcCommon::rotate was added for quaternion rotation on a vector. the implementation is matching in some functions, but has a register swap mismatch in others. it's as good as its gonna get for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/132)
<!-- Reviewable:end -->
