### PR TITLE
Adjust with `nnheaders` - `#27`

### DIFF
--- a/include/filedevice/nin/seadNinFileDeviceBaseNin.h
+++ b/include/filedevice/nin/seadNinFileDeviceBaseNin.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <nn/fs.h>
+#include <nn/fs/fs_types.h>
 #include "filedevice/seadFileDevice.h"
 #include "prim/seadSafeString.h"
 

--- a/modules/src/filedevice/nin/seadNinFileDeviceBaseNin.cpp
+++ b/modules/src/filedevice/nin/seadNinFileDeviceBaseNin.cpp
@@ -1,6 +1,9 @@
 #include "filedevice/nin/seadNinFileDeviceBaseNin.h"
 #include "filedevice/seadPath.h"
 
+#include <nn/fs/fs_directories.h>
+#include <nn/fs/fs_files.h>
+
 namespace sead
 {
 struct NinFileDeviceBase::FileHandleInner
@@ -398,8 +401,8 @@ bool NinFileDeviceBase::doReadDirectory_(u32* entries_read, DirectoryHandle* han
             return true;
         }
 
-        entries[i].name = entry.name;
-        entries[i].is_directory = entry.type == nn::fs::DirectoryEntryType_Directory;
+        entries[i].name = entry.mName;
+        entries[i].is_directory = entry.mTypeByte == nn::fs::DirectoryEntryType_Directory;
     }
 
     if (entries_read)

--- a/modules/src/filedevice/nin/seadNinSaveFileDeviceNin.cpp
+++ b/modules/src/filedevice/nin/seadNinSaveFileDeviceNin.cpp
@@ -1,5 +1,7 @@
 #include "filedevice/nin/seadNinSaveFileDeviceNin.h"
 
+#include <nn/fs/fs_save.h>
+
 namespace sead
 {
 NinSaveFileDevice::NinSaveFileDevice(const SafeString& mount) : NinFileDeviceBase("save", mount) {}

--- a/modules/src/filedevice/seadFileDeviceMgr.cpp
+++ b/modules/src/filedevice/seadFileDeviceMgr.cpp
@@ -4,7 +4,9 @@
 #endif  // cafe
 
 #ifdef NNSDK
-#include <nn/fs.h>
+#include <nn/fs/fs_mount.h>
+#include <nn/fs/fs_rom.h>
+#include <nn/fs/fs_save.h>
 #endif
 
 #include <basis/seadNew.h>


### PR DESCRIPTION
Adjusts the path of changed files/members to allow compiling again.

Should be merged along with https://github.com/open-ead/nnheaders/pull/27.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/133)
<!-- Reviewable:end -->
