### PR TITLE
Node is a struct, not a union

### DIFF
--- a/include/container/seadObjArray.h
+++ b/include/container/seadObjArray.h
@@ -213,7 +213,7 @@ public:
     T** data() const { return reinterpret_cast<T**>(mPtrs); }
 
 private:
-    union Node
+    struct Node
     {
         void* next_node;
         T elem;


### PR DESCRIPTION
The first 8 bytes of `elem` being shared with `next_node` makes no sense; they are stored separately. This is also confirmed by the memory layout of `ObjArray`s at runtime (specifically in Breath of the Wild).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/134)
<!-- Reviewable:end -->
