### PR TITLE
Vector3: implement set() in a different way

### DIFF
--- a/include/math/seadVector.hpp
+++ b/include/math/seadVector.hpp
@@ -77,7 +77,9 @@ inline Vector3<T>::Vector3(T x_, T y_, T z_)
 template <typename T>
 inline Vector3<T>& Vector3<T>::operator=(const Vector3<T>& other)
 {
-    Vector3CalcCommon<T>::set(*this, other);
+    this->x = other.x;
+    this->y = other.y;
+    this->z = other.z;
     return *this;
 }
 

--- a/include/math/seadVectorCalcCommon.hpp
+++ b/include/math/seadVectorCalcCommon.hpp
@@ -243,9 +243,7 @@ T Vector3CalcCommon<T>::normalize(Base& v)
 template <typename T>
 inline void Vector3CalcCommon<T>::set(Base& o, const Base& v)
 {
-    o.x = v.x;
-    o.y = v.y;
-    o.z = v.z;
+    o = v;
 }
 
 template <typename T>


### PR DESCRIPTION
This changes set() to rely on the BaseVec3 copy assignment operator rather than set x, y, z manually. Vector3's operator= seems to do the latter so it has been adjusted to not use set().

Everything in BotW still matches after this change, and this should let us get rid of a few ugly usages of `.e`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/135)
<!-- Reviewable:end -->
