### PR TITLE
container/TList: Change mList of node during insert

### DIFF
--- a/include/container/seadTList.h
+++ b/include/container/seadTList.h
@@ -35,11 +35,15 @@ public:
 
     void insertBefore(TListNode<T>* node, TListNode<T>* node_to_insert)
     {
+        node_to_insert->erase();
+        node_to_insert->mList = this;
         ListImpl::insertBefore(node, node_to_insert);
     }
 
     void insertAfter(TListNode<T>* node, TListNode<T>* node_to_insert)
     {
+        node_to_insert->erase();
+        node_to_insert->mList = this;
         ListImpl::insertAfter(node, node_to_insert);
     }
 


### PR DESCRIPTION
As discussed in Discord, we might want to change those two functions to be consistent with the `pushFront` and `pushBack`-functions above. I did not notice any regressions in `smo` or `botw` with this change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/136)
<!-- Reviewable:end -->
