### PR TITLE
math: Add `u32` variant to `Vector`s

### DIFF
--- a/include/math/seadVectorFwd.h
+++ b/include/math/seadVectorFwd.h
@@ -17,12 +17,15 @@ template <typename T>
 struct Vector4;
 
 using Vector2i = Vector2<s32>;
+using Vector2u = Vector2<u32>;
 using Vector2f = Vector2<f32>;
 
 using Vector3i = Vector3<s32>;
+using Vector3u = Vector3<u32>;
 using Vector3f = Vector3<f32>;
 
 using Vector4i = Vector4<s32>;
+using Vector4u = Vector4<u32>;
 using Vector4f = Vector4<f32>;
 
 }  // namespace sead


### PR DESCRIPTION
There seems to be another, very rarely used variant of the `sead::Vector` type, containing an `uint`/`u32` as elements.

In SMO, it can be observed in a bunch of `al::KCollisionServer` symbols, along with `al::Dynamic{Mesh, DrawActor, MeshDrawer}`. There also seems to be a single occurence in `agl::detail::SMAAResTextureGenerator::calcSearchEdgeFromKey`.

I can confirm that at least the `Vector3u` and `Vector4u` variants exist, I didn't find an occurence of `Vector2u` though - I find it very likely to exist as well though.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/137)
<!-- Reviewable:end -->
