### PR TITLE
math/seadVector: Adjust Vector2/4::set according to Vector3

### DIFF
--- a/include/math/seadVector.hpp
+++ b/include/math/seadVector.hpp
@@ -46,7 +46,8 @@ inline Vector2<T>& Vector2<T>::operator/=(T t)
 template <typename T>
 inline Vector2<T>& Vector2<T>::operator=(const Vector2<T>& other)
 {
-    Vector2CalcCommon<T>::set(*this, other);
+    this->x = other.x;
+    this->y = other.y;
     return *this;
 }
 
@@ -302,7 +303,10 @@ inline Vector4<T>& Vector4<T>::operator/=(T t)
 template <typename T>
 inline Vector4<T>& Vector4<T>::operator=(const Vector4<T>& other)
 {
-    Vector4CalcCommon<T>::set(*this, other);
+    this->x = other.x;
+    this->y = other.y;
+    this->z = other.z;
+    this->w = other.w;
     return *this;
 }
 

--- a/include/math/seadVectorCalcCommon.hpp
+++ b/include/math/seadVectorCalcCommon.hpp
@@ -29,8 +29,7 @@ inline void Vector2CalcCommon<T>::sub(Base& o, const Base& a, const Base& b)
 template <typename T>
 inline void Vector2CalcCommon<T>::set(Base& o, const Base& v)
 {
-    o.x = v.x;
-    o.y = v.y;
+    o = v;
 }
 
 template <typename T>
@@ -275,10 +274,7 @@ inline void Vector3CalcCommon<T>::set(Base& v, T x, T y, T z)
 template <typename T>
 inline void Vector4CalcCommon<T>::set(Base& o, const Base& v)
 {
-    o.x = v.x;
-    o.y = v.y;
-    o.z = v.z;
-    o.w = v.w;
+    o = v;
 }
 
 template <typename T>

--- a/modules/src/controller/seadControllerBase.cpp
+++ b/modules/src/controller/seadControllerBase.cpp
@@ -253,8 +253,8 @@ void ControllerBase::setIdleBase_()
     for (s32 i = 0; i < mPadBitMax; i++)
         mPadHoldCounts[i] = 0;
 
-    mPointer.set(cInvalidPointer);
-    mPointerS32.set(cInvalidPointerS32);
+    mPointer = cInvalidPointer;
+    mPointerS32 = cInvalidPointerS32;
     mLeftStick.set(0.0f, 0.0f);
     mRightStick.set(0.0f, 0.0f);
     mLeftAnalogTrigger = 0.0f;

--- a/modules/src/controller/seadControllerWrapper.cpp
+++ b/modules/src/controller/seadControllerWrapper.cpp
@@ -45,8 +45,8 @@ void ControllerWrapper::calc(u32 prev_hold, bool prev_pointer_on)
     {
         mPadHold = BitFlag32(createPadMaskFromControllerPadMask_(mController->getHoldMask()));
 
-        mLeftStick.set(mController->getLeftStick());
-        mRightStick.set(mController->getRightStick());
+        mLeftStick = mController->getLeftStick();
+        mRightStick = mController->getRightStick();
         mLeftAnalogTrigger = mController->getLeftAnalogTrigger();
         mRightAnalogTrigger = mController->getRightAnalogTrigger();
 


### PR DESCRIPTION
https://github.com/open-ead/sead/pull/135 adjusted it for Vector3, this will change it for Vector2 and Vector4 accordingly.

Two mismatches popped up across the whole `SMO` project, which are the two other files changed here: `sead::Controller` stuff, where I used `.set()` for some reason. Changing those to `=` assignments gets them matching again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/139)
<!-- Reviewable:end -->
