### PR TITLE
GameFrameworkNx: Add member variables

### DIFF
--- a/include/framework/nx/seadGameFrameworkNx.h
+++ b/include/framework/nx/seadGameFrameworkNx.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <framework/seadGameFramework.h>
+#include <gfx/seadFrameBuffer.h>
 #include <math/seadVector.h>
 #include <nvn/nvn.h>
 #include <thread/seadThread.h>
@@ -26,7 +27,11 @@ class GameFrameworkNx : public GameFramework
 {
     SEAD_RTTI_OVERRIDE(GameFrameworkNx, GameFramework)
 public:
-    struct CreateArg;
+    struct CreateArg
+    {
+        s32 mVBlankWaitInterval;
+        char _8[68];
+    };
 
     GameFrameworkNx(const CreateArg&);
     ~GameFrameworkNx() override;
@@ -58,20 +63,21 @@ public:
     void setCaption(const SafeString&);
 
 private:
-    int mVBlankWaitInterval;
-    int padding;
-    void* filler[10];
+    CreateArg mCreateArg;
+    char _E8[8];
+    u64 mSystemTick;
     FrameBuffer* mMethodFrameBuffer;
-    FrameBuffer* mMethodLogicalFrameBuffer;
-    void* filler2[4];
+    LogicalFrameBuffer mMethodLogicalFrameBuffer;
+    char _120[8];
     DisplayBufferNvn* mDisplayBuffer;
-    void* filler3[9];
+    char _130[72];
     nn::mem::StandardAllocator* mGraphicsDevToolsAllocator;
-    void* filler4[5];
+    char _180[40];
     nn::vi::Layer* mDisplay;
-    void* filler5[14];
+    char _1B0[96];
 };
 
-static_assert(sizeof(sead::GameFrameworkNx) == 0x220, "GameFrameworkNx size");
+static_assert(sizeof(sead::GameFrameworkNx) == 0x210, "GameFrameworkNx size");
+static_assert(sizeof(sead::GameFrameworkNx::CreateArg) == 0x48, "GameFrameworkNx::CreateArg size");
 
 }  // namespace sead

--- a/include/framework/nx/seadGameFrameworkNx.h
+++ b/include/framework/nx/seadGameFrameworkNx.h
@@ -7,6 +7,21 @@
 
 namespace sead
 {
+
+class DisplayBufferNvn;
+
+namespace nn
+{
+namespace mem
+{
+class StandardAllocator;
+}
+namespace vi
+{
+class Layer;
+}
+}  // namespace nn
+
 class GameFrameworkNx : public GameFramework
 {
     SEAD_RTTI_OVERRIDE(GameFrameworkNx, GameFramework)
@@ -42,7 +57,21 @@ public:
     float calcFps();
     void setCaption(const SafeString&);
 
-    // missing member variables
+private:
+    int mVBlankWaitInterval;
+    int padding;
+    void* filler[10];
+    FrameBuffer* mMethodFrameBuffer;
+    FrameBuffer* mMethodLogicalFrameBuffer;
+    void* filler2[4];
+    DisplayBufferNvn* mDisplayBuffer;
+    void* filler3[9];
+    nn::mem::StandardAllocator* mGraphicsDevToolsAllocator;
+    void* filler4[5];
+    nn::vi::Layer* mDisplay;
+    void* filler5[14];
 };
+
+static_assert(sizeof(sead::GameFrameworkNx) == 0x220, "GameFrameworkNx size");
 
 }  // namespace sead

--- a/include/framework/nx/seadGameFrameworkNx.h
+++ b/include/framework/nx/seadGameFrameworkNx.h
@@ -31,7 +31,7 @@ public:
         char _8[68];
     };
 
-    static_assert(sizeof(CreateArg) == 0x48, "");
+    static_assert(sizeof(CreateArg) == 0x48);
 
     GameFrameworkNx(const CreateArg&);
     ~GameFrameworkNx() override;
@@ -77,6 +77,6 @@ private:
     char _1B0[96];
 };
 
-static_assert(sizeof(GameFrameworkNx) == 0x210, "");
+static_assert(sizeof(GameFrameworkNx) == 0x210);
 
 }  // namespace sead

--- a/include/framework/nx/seadGameFrameworkNx.h
+++ b/include/framework/nx/seadGameFrameworkNx.h
@@ -8,9 +8,7 @@
 
 namespace sead
 {
-
 class DisplayBufferNvn;
-
 namespace nn
 {
 namespace mem
@@ -32,6 +30,8 @@ public:
         s32 mVBlankWaitInterval;
         char _8[68];
     };
+
+    static_assert(sizeof(CreateArg) == 0x48, "");
 
     GameFrameworkNx(const CreateArg&);
     ~GameFrameworkNx() override;
@@ -77,7 +77,6 @@ private:
     char _1B0[96];
 };
 
-static_assert(sizeof(sead::GameFrameworkNx) == 0x210, "GameFrameworkNx size");
-static_assert(sizeof(sead::GameFrameworkNx::CreateArg) == 0x48, "GameFrameworkNx::CreateArg size");
+static_assert(sizeof(GameFrameworkNx) == 0x210, "");
 
 }  // namespace sead


### PR DESCRIPTION
SMO's `al::GameFrameworkNx` requires the `sead` one to have the correct size. Besides filling the struct with the correct size, I also added some names and types based on @MonsterDruide1 's struct

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/141)
<!-- Reviewable:end -->
