### PR TITLE
math/seadQuatCalc: Add missing includes

### DIFF
--- a/include/math/seadQuatCalcCommon.h
+++ b/include/math/seadQuatCalcCommon.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <basis/seadTypes.h>
 #include <math/seadMathPolicies.h>
 
 namespace sead

--- a/include/math/seadQuatCalcCommon.hpp
+++ b/include/math/seadQuatCalcCommon.hpp
@@ -6,6 +6,7 @@
 
 #include <limits>
 #include <math/seadMathCalcCommon.h>
+#include <math/seadVectorCalcCommon.h>
 
 namespace sead
 {


### PR DESCRIPTION
This is the last PR of a series of PRs across all libraries, which will try to fix more issues with the current headers by introducing a new workflow on the `OdysseyDecomp` repo. As of right now, trying to compile certain combinations of headers or singular headers individually will fail, due to a number of reasons: Duplicate definitions, stubs that should have been replaced by including their proper definition, includes missing altogether and maybe more.

For this repo, only two includes were missing: `seadQuatCalcCommon.h` makes use of the `f32` type in `slerpTo` without previously defining it, so it should include `basis/seadTypes.h`. The implementation `.hpp` file uses `VectorCalcCommon` in `makeVectorRotation`, so it should include `math/seadVectorCalcCommon.h` as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/142)
<!-- Reviewable:end -->
