### PR TITLE
Add `sead::RegionID` and `sead::EnvUtil::getRegion` declarations

### DIFF
--- a/include/devenv/seadEnvUtil.h
+++ b/include/devenv/seadEnvUtil.h
@@ -6,12 +6,14 @@
 namespace sead
 {
 SEAD_ENUM(RegionLanguageID, JPja, USen, USes, USfr, USpt, EUen, EUes, EUfr, EUde, EUit, EUpt, EUnl, EUru, KRko, CNzh, TWzh)
+SEAD_ENUM(RegionID, JP, US, EU, KR, CN, TW)
 
 class EnvUtil
 {
 public:
     static const SafeString& getRomType();
     static RegionLanguageID getRegionLanguage();
+    static RegionID getRegion();
     static s32 getEnvironmentVariable(BufferedSafeString* out, const SafeString& variable);
     static s32 resolveEnvronmentVariable(BufferedSafeString* out, const SafeString& str);
 };


### PR DESCRIPTION
Needed by https://github.com/zeldaret/botw/pull/130
`LayoutResourceMgr` use the enum names to get the font files, so I am pretty sure the names are correct
![image](https://github.com/user-attachments/assets/c540820e-9a31-45a4-8045-2ab339e8112e)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/143)
<!-- Reviewable:end -->
