### PR TITLE
math/seadQuat: Adjust `operator=` to follow memory order

### DIFF
--- a/include/math/seadQuat.h
+++ b/include/math/seadQuat.h
@@ -22,10 +22,10 @@ public:
 
     Quat& operator=(const Quat& other)
     {
-        this->w = other.w;
         this->x = other.x;
         this->y = other.y;
         this->z = other.z;
+        this->w = other.w;
         return *this;
     }
 


### PR DESCRIPTION
It seems like `seadQuat`s prefer to be set in order of how they store their members, being `xyzw`. This PR fixes matching on `agl::utl::Parameter<sead::Quatf>::clone()` on both SMO and BotW, and does not introduce any regressions on both projects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/144)
<!-- Reviewable:end -->
