### PR TITLE
lint: Update `clang-format-lint-action` to `v0.17`

### DIFF
--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@v0.12
+    - uses: DoozyX/clang-format-lint-action@v0.17
       with:
         source: 'include modules'
         clangFormatVersion: 12


### PR DESCRIPTION
Fixes problems with python not finding `strtobool`, which caused linting to fail before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/145)
<!-- Reviewable:end -->
