### PR TITLE
framework/nx: Fix `nn` namespace in `GameFrameworkNx`

### DIFF
--- a/include/framework/nx/seadGameFrameworkNx.h
+++ b/include/framework/nx/seadGameFrameworkNx.h
@@ -6,9 +6,6 @@
 #include <nvn/nvn.h>
 #include <thread/seadThread.h>
 
-namespace sead
-{
-class DisplayBufferNvn;
 namespace nn
 {
 namespace mem
@@ -20,6 +17,10 @@ namespace vi
 class Layer;
 }
 }  // namespace nn
+
+namespace sead
+{
+class DisplayBufferNvn;
 
 class GameFrameworkNx : public GameFramework
 {


### PR DESCRIPTION
Apparently, the class declarations of `nn` have ended up within `sead` here. This is not only simply wrong, but also causes problems when trying to compile this file in combination with proper `nn::` usages, as those cannot be located, as the compiler assumes they should be under `nn::sead` then.

This issue can be fixed/corrected by moving the `nn` namespace here to outside of `sead`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/146)
<!-- Reviewable:end -->
