### PR TITLE
math/seadQuat: Implement `set(const Quat&)`-operator

### DIFF
--- a/include/math/seadQuat.h
+++ b/include/math/seadQuat.h
@@ -68,6 +68,7 @@ public:
 
     void makeUnit();
     bool makeVectorRotation(const Vec3& from, const Vec3& to);
+    void set(const Self& other);
     void set(T w, T x, T y, T z);
     void setRPY(T roll, T pitch, T yaw);
     void calcRPY(Vec3& rpy) const;

--- a/include/math/seadQuat.hpp
+++ b/include/math/seadQuat.hpp
@@ -74,6 +74,12 @@ inline bool Quat<T>::makeVectorRotation(const Vec3& from, const Vec3& to)
 }
 
 template <typename T>
+inline void Quat<T>::set(const Self& other)
+{
+    QuatCalcCommon<T>::set(*this, other);
+}
+
+template <typename T>
 inline void Quat<T>::set(T w_, T x_, T y_, T z_)
 {
     QuatCalcCommon<T>::set(*this, w_, x_, y_, z_);

--- a/include/math/seadQuatCalcCommon.h
+++ b/include/math/seadQuatCalcCommon.h
@@ -19,6 +19,7 @@ public:
     static void slerpTo(Base& out, const Base& q1, const Base& q2, f32 t);
     static void makeUnit(Base& q);
     static bool makeVectorRotation(Base& q, const Vec3& from, const Vec3& to);
+    static void set(Base& q, const Base& other);
     static void set(Base& q, T w, T x, T y, T z);
     static void setRPY(Base& q, T roll, T pitch, T yaw);
     static void setAxisAngle(Base& q, const Vec3& axis, T angle);

--- a/include/math/seadQuatCalcCommon.hpp
+++ b/include/math/seadQuatCalcCommon.hpp
@@ -118,6 +118,12 @@ inline bool QuatCalcCommon<T>::makeVectorRotation(Base& q, const Vec3& from, con
 }
 
 template <typename T>
+inline void QuatCalcCommon<T>::set(Base& q, const Base& other)
+{
+    q = other;
+}
+
+template <typename T>
 inline void QuatCalcCommon<T>::set(Base& q, T w, T x, T y, T z)
 {
     q.w = w;


### PR DESCRIPTION
Here, a new `set(const Quat&)` is added similar to the `set` functions in `Vector`s.

Here is an example of this function being used:
https://decomp.me/scratch/DMDBE
(weird casting to `Base` can be omitted by using `set` instead)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/148)
<!-- Reviewable:end -->
