### PR TITLE
gfx/LookAtCamera: Default Destructor

### DIFF
--- a/include/gfx/seadCamera.h
+++ b/include/gfx/seadCamera.h
@@ -49,7 +49,7 @@ class LookAtCamera : public Camera
 public:
     LookAtCamera() = default;
     LookAtCamera(const Vector3f& pos, const Vector3f& at, const Vector3f& up);
-    ~LookAtCamera() override;
+    ~LookAtCamera() override = default;
 
     void doUpdateMatrix(Matrix34f* dst) const override;
 


### PR DESCRIPTION
From Super Mario Odyssey:
`al::CameraInterpole` contains four `sead::LookAtCamera`s. During its destructor, these need to be destructed as well. Here, the destructor contains `sead::Camera::~Camera()` instead - which means that the destructor of `LookAtCamera` has been inlined, and thus must have been header-defined.

It can be written as
- `~LookAtCamera() override = default;`
- `~LookAtCamera() override {}`

... but I think the first option is preferred here - please correct me if the other option should've been used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/149)
<!-- Reviewable:end -->
