### PR TITLE
framework: Use SEAD_RTTI_OVERRIDE macro

### DIFF
--- a/include/framework/seadTask.h
+++ b/include/framework/seadTask.h
@@ -8,7 +8,7 @@ namespace sead
 {
 class Task : public TaskBase
 {
-    SEAD_RTTI_BASE(TaskBase);
+    SEAD_RTTI_OVERRIDE(Task, TaskBase);
 
 public:
     explicit Task(const TaskConstructArg& arg);


### PR DESCRIPTION
This fixes some warnings `overrides a member function but is not marked 'override'`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/151)
<!-- Reviewable:end -->
