### PR TITLE
math/Quat: Fix `setRPY`

### DIFF
--- a/include/math/seadQuatCalcCommon.hpp
+++ b/include/math/seadQuatCalcCommon.hpp
@@ -147,12 +147,10 @@ inline void QuatCalcCommon<T>::setRPY(Base& q, T roll, T pitch, T yaw)
     const T cy_sp = cy * sp;
     const T sy_cp = sy * cp;
 
-    const T w = (cy_cp * cr) + (sy_sp * sr);
-    const T x = (cy_cp * sr) - (sy_sp * cr);
-    const T y = (cy_sp * cr) + (sy_cp * sr);
-    const T z = (sy_cp * cr) - (cy_sp * sr);
-
-    set(q, w, x, y, z);
+    q.w = (cy_cp * cr) + (sy_sp * sr);
+    q.x = (cy_cp * sr) - (sy_sp * cr);
+    q.y = (cy_sp * cr) + (sy_cp * sr);
+    q.z = (sy_cp * cr) - (cy_sp * sr);
 }
 
 template <typename T>


### PR DESCRIPTION
The current implementation of `setRPY` mismatches on some functions in SMO, specifically `al::getQuat(sead::Quatf*, const al::PlacementInfo&)`, where the order of stores is being switched around by the compiler - which is apparently not possible with the current implementation. Changing this to the code suggested in this PR solves those mismatches, and does not introduce any new mismatches across SMO.

This change has not been tested with BotW (yet).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/152)
<!-- Reviewable:end -->
