### PR TITLE
math/Matrix: Fix `makeSRT`

### DIFF
--- a/include/math/seadMatrixCalcCommon.hpp
+++ b/include/math/seadMatrixCalcCommon.hpp
@@ -1542,16 +1542,20 @@ void Matrix34CalcCommon<T>::makeSRT(Base& o, const Vec3& s, const Vec3& r, const
     const T cosV[3] = {MathCalcCommon<T>::cos(r.x), MathCalcCommon<T>::cos(r.y),
                        MathCalcCommon<T>::cos(r.z)};
 
+    f32 c0_c2 = cosV[0] * cosV[2];
+    f32 s0_s1 = sinV[0] * sinV[1];
+    f32 c0_s2 = cosV[0] * sinV[2];
+
     o.m[0][0] = s.x * (cosV[1] * cosV[2]);
     o.m[1][0] = s.x * (cosV[1] * sinV[2]);
     o.m[2][0] = s.x * -sinV[1];
 
-    o.m[0][1] = s.y * (sinV[0] * sinV[1] * cosV[2] - cosV[0] * sinV[2]);
-    o.m[1][1] = s.y * (sinV[0] * sinV[1] * sinV[2] + cosV[0] * cosV[2]);
+    o.m[0][1] = s.y * (s0_s1 * cosV[2] - c0_s2);
+    o.m[1][1] = s.y * (s0_s1 * sinV[2] + c0_c2);
     o.m[2][1] = s.y * (sinV[0] * cosV[1]);
 
-    o.m[0][2] = s.z * (cosV[0] * cosV[2] * sinV[1] + sinV[0] * sinV[2]);
-    o.m[1][2] = s.z * (cosV[0] * sinV[2] * sinV[1] - sinV[0] * cosV[2]);
+    o.m[0][2] = s.z * (c0_c2 * sinV[1] + sinV[0] * sinV[2]);
+    o.m[1][2] = s.z * (c0_s2 * sinV[1] - sinV[0] * cosV[2]);
     o.m[2][2] = s.z * (cosV[0] * cosV[1]);
 
     o.m[0][3] = t.x;

--- a/include/math/seadMatrixCalcCommon.hpp
+++ b/include/math/seadMatrixCalcCommon.hpp
@@ -1542,9 +1542,9 @@ void Matrix34CalcCommon<T>::makeSRT(Base& o, const Vec3& s, const Vec3& r, const
     const T cosV[3] = {MathCalcCommon<T>::cos(r.x), MathCalcCommon<T>::cos(r.y),
                        MathCalcCommon<T>::cos(r.z)};
 
-    f32 c0_c2 = cosV[0] * cosV[2];
-    f32 s0_s1 = sinV[0] * sinV[1];
-    f32 c0_s2 = cosV[0] * sinV[2];
+    T c0_c2 = cosV[0] * cosV[2];
+    T s0_s1 = sinV[0] * sinV[1];
+    T c0_s2 = cosV[0] * sinV[2];
 
     o.m[0][0] = s.x * (cosV[1] * cosV[2]);
     o.m[1][0] = s.x * (cosV[1] * sinV[2]);


### PR DESCRIPTION
Change this implementation to look similar to the one of `makeRT`, pre-calculating some of the re-usable sin/cos products. This change allows `al::tryGetMatrixTRS(sead::Matrix34f*, const al::PlacementInfo&)` to match, and as it has not been used anywhere else so far, does not introduce regressions in SMO.

This has not been tested with BotW (yet).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/153)
<!-- Reviewable:end -->
