### PR TITLE
math: Fix `Vector3::rotate(const Quat&)`

### DIFF
--- a/include/math/seadVector.h
+++ b/include/math/seadVector.h
@@ -77,6 +77,7 @@ struct Vector3 : public Policies<T>::Vec3Base
 {
     using Mtx33 = typename Policies<T>::Mtx33Base;
     using Mtx34 = typename Policies<T>::Mtx34Base;
+    using Quat = typename Policies<T>::QuatBase;
 
     /// @warning This constructor leaves member variables uninitialized.
     Vector3() {}
@@ -148,6 +149,8 @@ struct Vector3 : public Policies<T>::Vec3Base
     void rotate(const Mtx33& m);
     /// Apply a rotation `m` to this vector.
     void rotate(const Mtx34& m);
+    /// Apply a rotation `q` to this vector.
+    void rotate(const Quat& q);
     void multScalar(T t);
 
     T normalize();
@@ -159,6 +162,7 @@ struct Vector3 : public Policies<T>::Vec3Base
     void setMul(const Mtx34& m, const Vector3& a);
     void setRotated(const Mtx33& m, const Vector3& a);
     void setRotated(const Mtx34& m, const Vector3& a);
+    void setRotated(const Quat& q, const Vector3& a);
 
     static const Vector3 zero;
     static const Vector3 ex;

--- a/include/math/seadVector.hpp
+++ b/include/math/seadVector.hpp
@@ -213,6 +213,12 @@ inline void Vector3<T>::rotate(const Mtx34& m)
 }
 
 template <typename T>
+inline void Vector3<T>::rotate(const Quat& q)
+{
+    setRotated(q, *this);
+}
+
+template <typename T>
 inline void Vector3<T>::multScalar(T t)
 {
     Vector3CalcCommon<T>::multScalar(*this, *this, t);
@@ -270,6 +276,12 @@ template <typename T>
 inline void Vector3<T>::setRotated(const Mtx34& m, const Vector3<T>& a)
 {
     Vector3CalcCommon<T>::rotate(*this, m, a);
+}
+
+template <typename T>
+inline void Vector3<T>::setRotated(const Quat& q, const Vector3<T>& a)
+{
+    Vector3CalcCommon<T>::rotate(*this, q, a);
 }
 
 template <typename T>

--- a/include/math/seadVectorCalcCommon.hpp
+++ b/include/math/seadVectorCalcCommon.hpp
@@ -148,7 +148,7 @@ inline void Vector3CalcCommon<T>::rotate(Base& o, const Quat& q, const Base& v)
     // quat-multiplication
     o.x = (q.w * r.x) - (q.z * r.y) + (q.y * r.z) + (q.x * r.w);
     o.y = (q.z * r.x) + (q.w * r.y) - (q.x * r.z) + (q.y * r.w);
-    o.z = (q.w * r.z) + (-(q.y * r.x) + (q.x * r.y)) + (q.z * r.w);
+    o.z = -(q.y * r.x) + (q.x * r.y) + (q.w * r.z) + (q.z * r.w);
 }
 
 template <typename T>


### PR DESCRIPTION
Fixes a mismatch by changing the equation order and allows to be used within the vector.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/156)
<!-- Reviewable:end -->
