### PR TITLE
remove deprecated `std::result_of_t`

### DIFF
--- a/include/prim/seadDelegate.h
+++ b/include/prim/seadDelegate.h
@@ -429,7 +429,7 @@ static auto makeLambdaDelegate(Lambda&& l)
 template <typename Lambda>
 static auto makeLambdaDelegateR(Lambda&& l)
 {
-    using R = std::result_of_t<Lambda()>;
+    using R = std::invoke_result_t<Lambda>;
     return LambdaDelegateR<Lambda, R>(std::forward<Lambda>(l));
 }
 
@@ -442,7 +442,7 @@ static auto makeLambdaDelegate1(Lambda&& l)
 template <typename A1, typename Lambda>
 static auto makeLambdaDelegate1R(Lambda&& l)
 {
-    using R = std::result_of_t<Lambda(A1)>;
+    using R = std::invoke_result_t<Lambda, A1>;
     return LambdaDelegate1R<Lambda, A1, R>(std::forward<Lambda>(l));
 }
 
@@ -455,7 +455,7 @@ static auto makeLambdaDelegate2(Lambda&& l)
 template <typename A1, typename A2, typename Lambda>
 static auto makeLambdaDelegate2R(Lambda&& l)
 {
-    using R = std::result_of_t<Lambda(A1, A2)>;
+    using R = std::invoke_result_t<Lambda, A1, A2>;
     return LambdaDelegate2R<Lambda, A1, A2, R>(std::forward<Lambda>(l));
 }
 


### PR DESCRIPTION
this type was deprecated in c++17 and removed in c++20, as far as i know this `std::invoke_result_t` should be equivalent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/157)
<!-- Reviewable:end -->
