### PR TITLE
`ControllerBase`: change member variables to `protected`

### DIFF
--- a/include/controller/seadControllerBase.h
+++ b/include/controller/seadControllerBase.h
@@ -59,6 +59,14 @@ public:
     const BoundBox2f& getPointerBound() const { return mPointerBound; }
 
 protected:
+    bool isIdleBase_();
+    void setIdleBase_();
+    void setPointerWithBound_(bool is_on, bool touchkey_hold, const Vector2f& pos);
+    void updateDerivativeParams_(u32 prev_hold, bool prev_pointer_on);
+    u32 getStickHold_(u32 prev_hold, const Vector2f& stick, f32 hold_threshold,
+                      f32 release_threshold, s32 start_bit);
+    u32 createStickCrossMask_();
+
     enum
     {
         cPadIdx_MaxBase = 32
@@ -79,14 +87,6 @@ protected:
         cCrossLeft,
         cCrossRight
     };
-
-    bool isIdleBase_();
-    void setIdleBase_();
-    void setPointerWithBound_(bool is_on, bool touchkey_hold, const Vector2f& pos);
-    void updateDerivativeParams_(u32 prev_hold, bool prev_pointer_on);
-    u32 getStickHold_(u32 prev_hold, const Vector2f& stick, f32 hold_threshold,
-                      f32 release_threshold, s32 start_bit);
-    u32 createStickCrossMask_();
 
     BitFlag32 mPadTrig;
     BitFlag32 mPadRelease;

--- a/include/controller/seadControllerBase.h
+++ b/include/controller/seadControllerBase.h
@@ -59,15 +59,6 @@ public:
     const BoundBox2f& getPointerBound() const { return mPointerBound; }
 
 protected:
-    bool isIdleBase_();
-    void setIdleBase_();
-    void setPointerWithBound_(bool is_on, bool touchkey_hold, const Vector2f& pos);
-    void updateDerivativeParams_(u32 prev_hold, bool prev_pointer_on);
-    u32 getStickHold_(u32 prev_hold, const Vector2f& stick, f32 hold_threshold,
-                      f32 release_threshold, s32 start_bit);
-    u32 createStickCrossMask_();
-
-private:
     enum
     {
         cPadIdx_MaxBase = 32
@@ -88,6 +79,14 @@ private:
         cCrossLeft,
         cCrossRight
     };
+
+    bool isIdleBase_();
+    void setIdleBase_();
+    void setPointerWithBound_(bool is_on, bool touchkey_hold, const Vector2f& pos);
+    void updateDerivativeParams_(u32 prev_hold, bool prev_pointer_on);
+    u32 getStickHold_(u32 prev_hold, const Vector2f& stick, f32 hold_threshold,
+                      f32 release_threshold, s32 start_bit);
+    u32 createStickCrossMask_();
 
     BitFlag32 mPadTrig;
     BitFlag32 mPadRelease;

--- a/include/prim/seadDelegate.h
+++ b/include/prim/seadDelegate.h
@@ -429,7 +429,7 @@ static auto makeLambdaDelegate(Lambda&& l)
 template <typename Lambda>
 static auto makeLambdaDelegateR(Lambda&& l)
 {
-    using R = std::result_of_t<Lambda>;
+    using R = std::result_of_t<Lambda()>;
     return LambdaDelegateR<Lambda, R>(std::forward<Lambda>(l));
 }
 

--- a/include/prim/seadDelegate.h
+++ b/include/prim/seadDelegate.h
@@ -429,7 +429,7 @@ static auto makeLambdaDelegate(Lambda&& l)
 template <typename Lambda>
 static auto makeLambdaDelegateR(Lambda&& l)
 {
-    using R = std::result_of_t<Lambda()>;
+    using R = std::invoke_result_t<Lambda>;
     return LambdaDelegateR<Lambda, R>(std::forward<Lambda>(l));
 }
 
@@ -442,7 +442,7 @@ static auto makeLambdaDelegate1(Lambda&& l)
 template <typename A1, typename Lambda>
 static auto makeLambdaDelegate1R(Lambda&& l)
 {
-    using R = std::result_of_t<Lambda(A1)>;
+    using R = std::invoke_result_t<Lambda, A1>;
     return LambdaDelegate1R<Lambda, A1, R>(std::forward<Lambda>(l));
 }
 
@@ -455,7 +455,7 @@ static auto makeLambdaDelegate2(Lambda&& l)
 template <typename A1, typename A2, typename Lambda>
 static auto makeLambdaDelegate2R(Lambda&& l)
 {
-    using R = std::result_of_t<Lambda(A1, A2)>;
+    using R = std::invoke_result_t<Lambda, A1, A2>;
     return LambdaDelegate2R<Lambda, A1, A2, R>(std::forward<Lambda>(l));
 }
 

--- a/include/prim/seadDelegate.h
+++ b/include/prim/seadDelegate.h
@@ -429,7 +429,7 @@ static auto makeLambdaDelegate(Lambda&& l)
 template <typename Lambda>
 static auto makeLambdaDelegateR(Lambda&& l)
 {
-    using R = std::invoke_result_t<Lambda>;
+    using R = std::result_of_t<Lambda>;
     return LambdaDelegateR<Lambda, R>(std::forward<Lambda>(l));
 }
 
@@ -442,7 +442,7 @@ static auto makeLambdaDelegate1(Lambda&& l)
 template <typename A1, typename Lambda>
 static auto makeLambdaDelegate1R(Lambda&& l)
 {
-    using R = std::invoke_result_t<Lambda, A1>;
+    using R = std::result_of_t<Lambda(A1)>;
     return LambdaDelegate1R<Lambda, A1, R>(std::forward<Lambda>(l));
 }
 
@@ -455,7 +455,7 @@ static auto makeLambdaDelegate2(Lambda&& l)
 template <typename A1, typename A2, typename Lambda>
 static auto makeLambdaDelegate2R(Lambda&& l)
 {
-    using R = std::invoke_result_t<Lambda, A1, A2>;
+    using R = std::result_of_t<Lambda(A1, A2)>;
     return LambdaDelegate2R<Lambda, A1, A2, R>(std::forward<Lambda>(l));
 }
 


### PR DESCRIPTION
in odyssey (and i think in 3DW/3DL as well), the `al::ReplayController` class, which derives from `sead::ControllerBase`, modifies `mPadTrig`, `mPadHold`, `mLeftStick` and `mPointer`, as can be seen [here](https://github.com/tetraxile/OdysseyDecomp/blob/0b9c2ceebeabb6c095b8d5ab76ee3ce0cd231b78/lib/al/Library/Controller/ReplayController.cpp#L56).

unsure if it's the best way to handle it to just make everything `protected` for this class, but `mPointer` is way down the bottom of the class so it'd be pretty messy to only make some `private` and some `protected`. also may be a bit excessive to add `protected` setters for everything. i think this is the cleanest way to handle it, hopefully it doesn't break something else.

also sorry for the messy commit history here i accidentally did my previous PR on the `master` branch :3 perhaps they could be squashed if this gets merged

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/159)
<!-- Reviewable:end -->
