### PR TITLE
math/Quat: Fix `makeUnit`

### DIFF
--- a/include/math/seadQuatCalcCommon.hpp
+++ b/include/math/seadQuatCalcCommon.hpp
@@ -92,7 +92,7 @@ inline void QuatCalcCommon<T>::slerpTo(Base& out, const Base& q1, const Base& q2
 template <typename T>
 inline void QuatCalcCommon<T>::makeUnit(Base& q)
 {
-    q = {1, 0, 0, 0};
+    q = {0, 0, 0, 1};
 }
 
 template <typename T>


### PR DESCRIPTION
Follow-up PR to #150. Over there, `makeUnit` was created by copying how `sead::Quatf::unit` is done - however, the order of parameters for the constructor are different between `sead::Quat`, being `w, x, y, z`, and its `Policies::QuatBase`, which has `x, y, z, w` instead. As `makeUnit` constructs an `Base&`, it has to use the order `x, y, z, w` - specifying the `1` at the last position.