### PR TITLE
prim/LambdaDelegate: Check standard version for `std::invoke_result_t`

### DIFF
--- a/include/prim/seadDelegate.h
+++ b/include/prim/seadDelegate.h
@@ -429,7 +429,11 @@ static auto makeLambdaDelegate(Lambda&& l)
 template <typename Lambda>
 static auto makeLambdaDelegateR(Lambda&& l)
 {
+#if __cplusplus < 202002L
+    using R = std::result_of_t<Lambda()>;
+#else
     using R = std::invoke_result_t<Lambda>;
+#endif
     return LambdaDelegateR<Lambda, R>(std::forward<Lambda>(l));
 }
 
@@ -442,7 +446,11 @@ static auto makeLambdaDelegate1(Lambda&& l)
 template <typename A1, typename Lambda>
 static auto makeLambdaDelegate1R(Lambda&& l)
 {
+#if __cplusplus < 202002L
+    using R = std::result_of_t<Lambda(A1)>;
+#else
     using R = std::invoke_result_t<Lambda, A1>;
+#endif
     return LambdaDelegate1R<Lambda, A1, R>(std::forward<Lambda>(l));
 }
 
@@ -455,7 +463,11 @@ static auto makeLambdaDelegate2(Lambda&& l)
 template <typename A1, typename A2, typename Lambda>
 static auto makeLambdaDelegate2R(Lambda&& l)
 {
+#if __cplusplus < 202002L
+    using R = std::result_of_t<Lambda(A1, A2)>;
+#else
     using R = std::invoke_result_t<Lambda, A1, A2>;
+#endif
     return LambdaDelegate2R<Lambda, A1, A2, R>(std::forward<Lambda>(l));
 }
 


### PR DESCRIPTION
as mentioned in #157, there were indeed some compilation issues resulting from this: `OdysseyDecomp` uses `c++1z`, which doesn't yet have `std::invoke_result_t`. to get around this i just added some preprocessor `#if`s to check that the standard version is below `c++20`, in which case it will just use `std::result_of_t` as it did before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/164)
<!-- Reviewable:end -->
