### PR TITLE
README: Adjust compiler compatibility note

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Platform-specific files are usually placed into a subdirectory that is called:
 
 Building this project requires:
 
-- A C++17 capable compiler (or >= Clang 4.0). While older parts of sead are written in C++03, the newer modules in sead target C++11 (or newer) and recent C++ language or library features make writing C++ more convenient.
+- A partially C++17 capable compiler (like >= Clang 3.9). While older parts of sead are written in C++03, the newer modules in sead target C++11 (or newer) and recent C++ language or library features make writing C++ more convenient. Not all features of C++17 are utilized, compilers supporting parts of C++1z might be enough to compile the project.
 - CMake 3.10+
 
 ### Configuration


### PR DESCRIPTION
In PR #164, we determined that the `README` should be adjusted to better reflect the compiler compatibility of this project.

We cannot fully go down to `C++14`, because there are way more features we use from `C++1z`: `constexpr`, `inline` variables, nested `namespace nn::oe`, which already at least cause warnings when compiled with `C++14`. But most importantly, causing actual errors: `is_always_lock_free` on `std::atomic`, which has been introduced by `C++17` (<https://en.cppreference.com/w/cpp/atomic/atomic/is_always_lock_free>) ; and `std::size`, also `C++17`-only (<https://en.cppreference.com/w/cpp/iterator/size>).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/168)
<!-- Reviewable:end -->
