### PR TITLE
container: Remove `StrTreeMap`-destructor

### DIFF
--- a/include/container/seadStrTreeMap.h
+++ b/include/container/seadStrTreeMap.h
@@ -38,8 +38,6 @@ public:
         char mKeyData[MaxKeyLength + 1];
     };
 
-    ~StrTreeMap();
-
     void allocBuffer(s32 node_max, Heap* heap, s32 alignment = sizeof(void*));
     void setBuffer(s32 node_max, void* buffer);
     void freeBuffer();
@@ -69,17 +67,6 @@ inline void StrTreeMap<N, Value>::Node::erase_()
     // Note: Nintendo does not call the destructor, which is dangerous...
     map->mFreeList.free(this_);
     --map->mSize;
-}
-
-template <size_t N, typename Value>
-inline StrTreeMap<N, Value>::~StrTreeMap()
-{
-    void* work = mFreeList.work();
-    if (!work)
-        return;
-
-    clear();
-    freeBuffer();
 }
 
 template <size_t N, typename Value>


### PR DESCRIPTION
As specified by #118, and required by https://github.com/MonsterDruide1/OdysseyDecomp/pull/442, the destructor of `StrTreeMap` should be removed. This PR closely follows what has been done to `TreeMap` in https://github.com/open-ead/sead/commit/eadee1e89cee0065c767bbe8963d4630b9b424ee.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/169)
<!-- Reviewable:end -->
