### PR TITLE
container: Change `StrTreeMap` template type to `s32`

### DIFF
--- a/include/container/seadStrTreeMap.h
+++ b/include/container/seadStrTreeMap.h
@@ -10,7 +10,7 @@ namespace sead
 {
 /// Sorted associative container with fixed-length string keys.
 /// This is essentially std::map<char[MaxKeyLength], Value>
-template <size_t MaxKeyLength, typename Value>
+template <s32 MaxKeyLength, typename Value>
 class StrTreeMap : public TreeMapImpl<SafeString>
 {
 public:
@@ -61,7 +61,7 @@ private:
     s32 mCapacity = 0;
 };
 
-template <size_t N, typename Value>
+template <s32 N, typename Value>
 inline void StrTreeMap<N, Value>::Node::erase_()
 {
     StrTreeMap* const map = mMap;
@@ -71,7 +71,7 @@ inline void StrTreeMap<N, Value>::Node::erase_()
     --map->mSize;
 }
 
-template <size_t N, typename Value>
+template <s32 N, typename Value>
 inline StrTreeMap<N, Value>::~StrTreeMap()
 {
     void* work = mFreeList.work();
@@ -82,7 +82,7 @@ inline StrTreeMap<N, Value>::~StrTreeMap()
     freeBuffer();
 }
 
-template <size_t N, typename Value>
+template <s32 N, typename Value>
 inline void StrTreeMap<N, Value>::allocBuffer(s32 node_max, Heap* heap, s32 alignment)
 {
     SEAD_ASSERT(mFreeList.work() == nullptr);
@@ -97,14 +97,14 @@ inline void StrTreeMap<N, Value>::allocBuffer(s32 node_max, Heap* heap, s32 alig
         setBuffer(node_max, work);
 }
 
-template <size_t N, typename Value>
+template <s32 N, typename Value>
 inline void StrTreeMap<N, Value>::setBuffer(s32 node_max, void* buffer)
 {
     mCapacity = node_max;
     mFreeList.setWork(buffer, sizeof(Node), node_max);
 }
 
-template <size_t N, typename Value>
+template <s32 N, typename Value>
 inline void StrTreeMap<N, Value>::freeBuffer()
 {
     void* buffer = mFreeList.work();
@@ -116,7 +116,7 @@ inline void StrTreeMap<N, Value>::freeBuffer()
     mFreeList.reset();
 }
 
-template <size_t N, typename Value>
+template <s32 N, typename Value>
 inline Value* StrTreeMap<N, Value>::insert(const SafeString& key, const Value& value)
 {
     if (mSize >= mCapacity)
@@ -136,7 +136,7 @@ inline Value* StrTreeMap<N, Value>::insert(const SafeString& key, const Value& v
     return &node->value();
 }
 
-template <size_t N, typename Value>
+template <s32 N, typename Value>
 inline void StrTreeMap<N, Value>::clear()
 {
     Delegate1<StrTreeMap<N, Value>, typename MapImpl::Node*> delegate(
@@ -146,13 +146,13 @@ inline void StrTreeMap<N, Value>::clear()
     MapImpl::clear();
 }
 
-template <size_t N, typename Value>
+template <s32 N, typename Value>
 inline typename StrTreeMap<N, Value>::Node* StrTreeMap<N, Value>::find(const SafeString& key) const
 {
     return static_cast<Node*>(MapImpl::find(key));
 }
 
-template <size_t N, typename Value>
+template <s32 N, typename Value>
 template <typename Callable>
 inline void StrTreeMap<N, Value>::forEach(const Callable& delegate) const
 {
@@ -162,7 +162,7 @@ inline void StrTreeMap<N, Value>::forEach(const Callable& delegate) const
     });
 }
 
-template <size_t N, typename Value>
+template <s32 N, typename Value>
 inline void StrTreeMap<N, Value>::eraseNodeForClear_(typename MapImpl::Node* node)
 {
     // Note: Nintendo does not call the destructor, which is dangerous...


### PR DESCRIPTION
`sead10StrTreeMapILi` shows the template type being `i` = `s32`, whereas it is currently generating `ILm` for `m` = `size_t` = `u64`. The symbol is visible in SMO, and is also already listed with `i` in BotW's function CSV, although not implemented/used yet.