### PR TITLE
prim: Add missing include in `StorageFor`

### DIFF
--- a/include/prim/seadStorageFor.h
+++ b/include/prim/seadStorageFor.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <utility>
+
+#include "basis/seadNew.h"
 #include "basis/seadTypes.h"
 
 namespace sead


### PR DESCRIPTION
As the two `construct`-methods (`construct()` and `constructDefault()`) call `operator new`, the correct implementation should be provided here, by including `seadNew.h`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/171)
<!-- Reviewable:end -->
