### PR TITLE
math: Add `Vector3::setSub`

### DIFF
--- a/include/math/seadVector.h
+++ b/include/math/seadVector.h
@@ -165,6 +165,7 @@ struct Vector3 : public Policies<T>::Vec3Base
     void setRotated(const Mtx33& m, const Vector3& a);
     void setRotated(const Mtx34& m, const Vector3& a);
     void setRotated(const Quat& q, const Vector3& a);
+    void setSub(const Vector3& a, const Vector3& b);
 
     static const Vector3 zero;
     static const Vector3 ex;

--- a/include/math/seadVector.hpp
+++ b/include/math/seadVector.hpp
@@ -297,6 +297,12 @@ inline void Vector3<T>::setRotated(const Quat& q, const Vector3<T>& a)
 }
 
 template <typename T>
+inline void Vector3<T>::setSub(const Vector3<T>& a, const Vector3<T>& b)
+{
+    Vector3CalcCommon<T>::sub(*this, a, b);
+}
+
+template <typename T>
 inline Vector4<T>::Vector4(T x_, T y_, T z_, T w_)
 {
     Vector4CalcCommon<T>::set(*this, x_, y_, z_, w_);


### PR DESCRIPTION
Required for matching some functions within `Library/LiveActor/ActorMovementFunction.cpp` in SMO. Even manually calling `sead::Vector3CalcCommon<f32>::sub` did cause a mismatch with one example, which got resolved when using this newly introduced `setSub` instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/173)
<!-- Reviewable:end -->
