### PR TITLE
math: Add `Vector3::setScale`

### DIFF
--- a/include/math/seadVector.h
+++ b/include/math/seadVector.h
@@ -159,6 +159,7 @@ struct Vector3 : public Policies<T>::Vec3Base
     void set(const Vector3& other);
     void set(T x, T y, T z);
     void setCross(const Vector3<T>& a, const Vector3<T>& b);
+    void setScale(const Vector3<T>& a, T t);
     void setScaleAdd(T t, const Vector3<T>& a, const Vector3<T>& b);
     void setMul(const Mtx33& m, const Vector3& a);
     void setMul(const Mtx34& m, const Vector3& a);

--- a/include/math/seadVector.hpp
+++ b/include/math/seadVector.hpp
@@ -261,6 +261,12 @@ inline void Vector3<T>::setCross(const Vector3<T>& a, const Vector3<T>& b)
 }
 
 template <typename T>
+inline void Vector3<T>::setScale(const Vector3<T>& a, T t)
+{
+    Vector3CalcCommon<T>::multScalar(*this, a, t);
+}
+
+template <typename T>
 inline void Vector3<T>::setScaleAdd(T t, const Vector3<T>& a, const Vector3<T>& b)
 {
     Vector3CalcCommon<T>::multScalarAdd(*this, t, a, b);


### PR DESCRIPTION
Helps in matching some functions within `Library/LiveActor/ActorMovementFunction.cpp` in SMO. Manually calling `sead::Vector3CalcCommon<f32>::multScalar` or doing a dimension-wise multiplication also resulted in a match for all usages, but I adding a function like this would make things easier/shorter to match.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/174)
<!-- Reviewable:end -->
