### PR TITLE
container: Fix `allocBuffer` in `[Str]TreeMap`

### DIFF
--- a/include/container/seadStrTreeMap.h
+++ b/include/container/seadStrTreeMap.h
@@ -74,14 +74,16 @@ inline void StrTreeMap<N, Value>::Node::erase_()
 template <s32 N, typename Value>
 inline void StrTreeMap<N, Value>::allocBuffer(s32 node_max, Heap* heap, s32 alignment)
 {
+    s32 node_size = sizeof(Node);
+
     SEAD_ASSERT(mFreeList.work() == nullptr);
     if (node_max <= 0)
     {
         SEAD_ASSERT_MSG(false, "node_max[%d] must be larger than zero", node_max);
-        AllocFailAssert(heap, node_max * sizeof(Node), alignment);
+        AllocFailAssert(heap, node_max * node_size, alignment);
     }
 
-    void* work = AllocBuffer(node_max * sizeof(Node), heap, alignment);
+    void* work = AllocBuffer(node_max * node_size, heap, alignment);
     if (work)
         setBuffer(node_max, work);
 }

--- a/include/container/seadTreeMap.h
+++ b/include/container/seadTreeMap.h
@@ -503,14 +503,16 @@ inline void TreeMap<Key, Value>::Node::erase_()
 template <typename Key, typename Value>
 inline void TreeMap<Key, Value>::allocBuffer(s32 node_max, Heap* heap, s32 alignment)
 {
+    s32 node_size = sizeof(Node);
+
     SEAD_ASSERT(mFreeList.work() == nullptr);
     if (node_max <= 0)
     {
         SEAD_ASSERT_MSG(false, "node_max[%d] must be larger than zero", node_max);
-        AllocFailAssert(heap, node_max * sizeof(Node), alignment);
+        AllocFailAssert(heap, node_max * node_size, alignment);
     }
 
-    void* work = AllocBuffer(node_max * sizeof(Node), heap, alignment);
+    void* work = AllocBuffer(node_max * node_size, heap, alignment);
     if (work)
         setBuffer(node_max, work);
 }


### PR DESCRIPTION
As required by `BirdPlayerGlideCtrl::init` in https://github.com/MonsterDruide1/OdysseyDecomp/pull/442, this allocation function should cache the `sizeof` before going into the allocation or failure branches. The current implementation mismatches there.

Only `StrTreeMap` is required to be fixed for that PR, but as `TreeMap` is very similar with its implementation, it probably makes sense to change it there accordingly.

This change has been tested in SMO and BotW and does not introduce any mismatches in either project.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/175)
<!-- Reviewable:end -->
