### PR TITLE
container: Fix `insert` in `[Str]TreeMap`

### DIFF
--- a/include/container/seadStrTreeMap.h
+++ b/include/container/seadStrTreeMap.h
@@ -108,21 +108,26 @@ inline void StrTreeMap<N, Value>::freeBuffer()
 template <s32 N, typename Value>
 inline Value* StrTreeMap<N, Value>::insert(const SafeString& key, const Value& value)
 {
-    if (mSize >= mCapacity)
+    Value* ptr = nullptr;
+
+    if (mSize < mCapacity)
     {
-        if (Node* node = find(key))
-        {
-            node->value() = value;
-            return &node->value();
-        }
+        Node* node = new (mFreeList.alloc()) Node(this, key, value);
+        ptr = &node->value();
+        ++mSize;
+        MapImpl::insert(node);
+    }
+    else if (Node* node = find(key))
+    {
+        ptr = &node->value();
+        new (ptr) Value(value);
+    }
+    else
+    {
         SEAD_ASSERT_MSG(false, "map is full.");
-        return nullptr;
     }
 
-    Node* node = new (mFreeList.alloc()) Node(this, key, value);
-    ++mSize;
-    MapImpl::insert(node);
-    return &node->value();
+    return ptr;
 }
 
 template <s32 N, typename Value>

--- a/include/container/seadTreeMap.h
+++ b/include/container/seadTreeMap.h
@@ -537,21 +537,26 @@ inline void TreeMap<Key, Value>::freeBuffer()
 template <typename Key, typename Value>
 inline Value* TreeMap<Key, Value>::insert(const Key& key, const Value& value)
 {
-    if (mSize >= mCapacity)
+    Value* ptr = nullptr;
+
+    if (mSize < mCapacity)
     {
-        if (Node* node = find(key))
-        {
-            node->value() = value;
-            return &node->value();
-        }
+        Node* node = new (mFreeList.alloc()) Node(this, key, value);
+        ptr = &node->value();
+        ++mSize;
+        MapImpl::insert(node);
+    }
+    else if (Node* node = find(key))
+    {
+        ptr = &node->value();
+        new (ptr) Value(value);
+    }
+    else
+    {
         SEAD_ASSERT_MSG(false, "map is full.");
-        return nullptr;
     }
 
-    Node* node = new (mFreeList.alloc()) Node(this, key, value);
-    ++mSize;
-    MapImpl::insert(node);
-    return &node->value();
+    return ptr;
 }
 
 template <typename Key, typename Value>


### PR DESCRIPTION
Implementation as required by https://github.com/MonsterDruide1/OdysseyDecomp/pull/442.

It is possible to remove the `Value* ptr` variable and put immediate returns everywhere, but I think this one is a bit nicer. Switching the `mSize < mCapacity` to `mSize >= mCapacity` causes a mismatch, and removing the final `else` while using early returns also mismatches.

This change has been tested with SMO and BotW and does not introduce any new mismatches - BotW apparently checks some `TreeMap::insert` already, but it is unaffected by this change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/176)
<!-- Reviewable:end -->
