### PR TITLE
container: Fix RingBuffer::forcePushBack

### DIFF
--- a/include/container/seadRingBuffer.h
+++ b/include/container/seadRingBuffer.h
@@ -249,17 +249,15 @@ public:
     T* data() { return mBuffer; }
     const T* data() const { return mBuffer; }
 
-    void forcePushBack(const T& item)
+    bool forcePushBack(const T& item)
     {
-        if (mSize < mCapacity)
+        if (!pushBack(item))
         {
-            pushBack(item);
-            return;
-        }
-
-        if (mSize >= 1)
             popFront();
-        pushBack(item);
+            pushBack(item);
+            return false;
+        }
+        return true;
     }
 
     bool pushBack(const T& item)

--- a/include/container/seadRingBuffer.h
+++ b/include/container/seadRingBuffer.h
@@ -251,13 +251,13 @@ public:
 
     bool forcePushBack(const T& item)
     {
-        if (!pushBack(item))
+        bool isEnoughSpace = pushBack(item);
+        if (!isEnoughSpace)
         {
             popFront();
             pushBack(item);
-            return false;
         }
-        return true;
+        return isEnoughSpace;
     }
 
     bool pushBack(const T& item)


### PR DESCRIPTION
This function wasn't implemented properly and caused a mismatch. None of the repositories make use of it at the moment but is required to match HackFork::updateInput

The new implementation is from looking at other ring buffer implementations of open source projects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/177)
<!-- Reviewable:end -->
