### PR TITLE
Controller: Fix usages of `DynamicCast`

### DIFF
--- a/include/controller/seadController.h
+++ b/include/controller/seadController.h
@@ -83,7 +83,7 @@ T Controller::getAddonAs() const
 {
     for (auto& addon : mAddons)
     {
-        T result = DynamicCast<std::remove_pointer<T>>(addon);
+        T result = DynamicCast<typename std::remove_pointer<T>>(addon);
         if (result)
             return result;
     }

--- a/include/controller/seadControllerMgr.h
+++ b/include/controller/seadControllerMgr.h
@@ -89,7 +89,7 @@ T ControllerMgr::getControllerByOrderAs(s32 index) const
 {
     for (PtrArray<Controller>::iterator it = mControllers.begin(); it != mControllers.end(); ++it)
     {
-        T controller = DynamicCast<std::remove_pointer<T>::type>(&(*it));
+        T controller = DynamicCast<typename std::remove_pointer<T>::type>(&(*it));
         if (controller)
         {
             if (index == 0)
@@ -107,7 +107,7 @@ T ControllerMgr::getControlDeviceAs() const
 {
     for (OffsetList<ControlDevice>::iterator it = mDevices.begin(); it != mDevices.end(); ++it)
     {
-        T device = DynamicCast<std::remove_pointer<T>::type>(&(*it));
+        T device = DynamicCast<typename std::remove_pointer<T>::type>(&(*it));
         if (device)
             return device;
     }


### PR DESCRIPTION
As reported by @tetraxile, our current implementation throws errors when trying to use any of the templated functions using `DynamicCast` - because the compiler struggles to understand that `::type` is a type and not a variable here. By adding `typename` there, this is fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/179)
<!-- Reviewable:end -->
