### PR TITLE
math: Add `BoundBox3::Set[Min Max][X Y Z]` functions

### DIFF
--- a/include/math/seadBoundBox.h
+++ b/include/math/seadBoundBox.h
@@ -86,6 +86,12 @@ struct BoundBox3
     void set(const Vector3& min, const Vector3& max);
     void setMin(const Vector3& min);
     void setMax(const Vector3& max);
+    void setMinX(T x);
+    void setMinY(T y);
+    void setMinZ(T z);
+    void setMaxX(T x);
+    void setMaxY(T y);
+    void setMaxZ(T z);
     void offset(T dx, T dy, T dz);
     void offset(const Vector3& dv);
     void scaleX(T sx);

--- a/include/math/seadBoundBox.hpp
+++ b/include/math/seadBoundBox.hpp
@@ -233,6 +233,42 @@ inline void BoundBox3<T>::setMax(const Vector3& max)
 }
 
 template <typename T>
+inline void BoundBox3<T>::setMinX(T x)
+{
+    mMin.x = x;
+}
+
+template <typename T>
+inline void BoundBox3<T>::setMinY(T y)
+{
+    mMin.y = y;
+}
+
+template <typename T>
+inline void BoundBox3<T>::setMinZ(T z)
+{
+    mMin.z = z;
+}
+
+template <typename T>
+inline void BoundBox3<T>::setMaxX(T x)
+{
+    mMax.x = x;
+}
+
+template <typename T>
+inline void BoundBox3<T>::setMaxY(T y)
+{
+    mMax.y = y;
+}
+
+template <typename T>
+inline void BoundBox3<T>::setMaxZ(T z)
+{
+    mMax.z = z;
+}
+
+template <typename T>
 inline void BoundBox3<T>::offset(T dx, T dy, T dz)
 {
     mMin.x += dx;


### PR DESCRIPTION
This PR add `BoundBox3::Set[Min Max][X Y Z]` functions.

These functions are needed for https://github.com/MonsterDruide1/OdysseyDecomp/pull/447