### PR TITLE
`controller`: make `Controller::mId` protected

### DIFF
--- a/include/controller/seadController.h
+++ b/include/controller/seadController.h
@@ -65,8 +65,9 @@ protected:
     virtual bool isIdle_();
     virtual void setIdle_();
 
-private:
     ControllerDefine::ControllerId mId;
+    
+private:
     ControllerMgr* mMgr;
     OffsetList<ControllerAddon> mAddons;
     OffsetList<ControllerWrapperBase> mWrappers;

--- a/include/controller/seadController.h
+++ b/include/controller/seadController.h
@@ -66,7 +66,7 @@ protected:
     virtual void setIdle_();
 
     ControllerDefine::ControllerId mId;
-    
+
 private:
     ControllerMgr* mMgr;
     OffsetList<ControllerAddon> mAddons;


### PR DESCRIPTION
classes that inherit from this one need to set their `mId`, e.g. `al::NpadController`'s ctor in SMO.

could make this a setter if necessary but i think it makes sense to just be protected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/184)
<!-- Reviewable:end -->
