### PR TITLE
Math: Add normalize and length support for Vector4 types

### DIFF
--- a/include/math/seadVector.h
+++ b/include/math/seadVector.h
@@ -215,7 +215,10 @@ struct Vector4 : public Policies<T>::Vec4Base
     }
     bool operator!=(const Vector4& rhs) const { return !operator==(rhs); }
 
+    T normalize();
     void negate();
+    T length() const;
+    T squaredLength() const;
     void set(const Vector4& v);
     void set(T x_, T y_, T z_, T w_);
 

--- a/include/math/seadVector.hpp
+++ b/include/math/seadVector.hpp
@@ -365,9 +365,27 @@ inline Vector4<T>& Vector4<T>::operator=(const Vector4<T>& other)
 }
 
 template <typename T>
+inline T Vector4<T>::normalize()
+{
+    return Vector4CalcCommon<T>::normalize(*this);
+}
+
+template <typename T>
 inline void Vector4<T>::negate()
 {
     Vector4CalcCommon<T>::negate(*this);
+}
+
+template <typename T>
+inline T Vector4<T>::length() const
+{
+    return Vector4CalcCommon<T>::length(*this);
+}
+
+template <typename T>
+inline T Vector4<T>::squaredLength() const
+{
+    return Vector4CalcCommon<T>::squaredLength(*this);
 }
 
 template <typename T>

--- a/include/math/seadVectorCalcCommon.h
+++ b/include/math/seadVectorCalcCommon.h
@@ -67,7 +67,10 @@ public:
     using Base = typename Policies<T>::Vec4Base;
 
 public:
+    static T normalize(Base& v);
     static void negate(Base& v);
+    static T squaredLength(const Base& v);
+    static T length(const Base& v);
     static void set(Base& o, const Base& v);
     static void set(Base& v, T x, T y, T z, T w);
 };

--- a/include/math/seadVectorCalcCommon.hpp
+++ b/include/math/seadVectorCalcCommon.hpp
@@ -298,12 +298,40 @@ inline void Vector3CalcCommon<T>::set(Base& v, T x, T y, T z)
 }
 
 template <typename T>
+T Vector4CalcCommon<T>::normalize(Base& v)
+{
+    const T len = length(v);
+    if (len > 0)
+    {
+        const T inv_len = 1 / len;
+        v.x *= inv_len;
+        v.y *= inv_len;
+        v.z *= inv_len;
+        v.w *= inv_len;
+    }
+
+    return len;
+}
+
+template <typename T>
 inline void Vector4CalcCommon<T>::negate(Base& v)
 {
     v.x = -v.x;
     v.y = -v.y;
     v.z = -v.z;
     v.w = -v.w;
+}
+
+template <typename T>
+inline T Vector4CalcCommon<T>::squaredLength(const Base& v)
+{
+    return v.x * v.x + v.y * v.y + v.z * v.z + v.w * v.w;
+}
+
+template <typename T>
+inline T Vector4CalcCommon<T>::length(const Base& v)
+{
+    return MathCalcCommon<T>::sqrt(squaredLength(v));
 }
 
 template <typename T>


### PR DESCRIPTION
I can't believe normalize and length didn't exist yet. ~~`al::calcLongitudeLatitudeFromDir` uses Vector2f math so I need these to implement the function properly.~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/185)
<!-- Reviewable:end -->
