### PR TITLE
Math: Add matrix overloads for getters and implement get/set-Base/Row for Matrix33

### DIFF
--- a/include/math/seadMatrix.h
+++ b/include/math/seadMatrix.h
@@ -93,6 +93,14 @@ public:
     void makeSRzxyIdx(const Vec3& s, const Vector3<u32>& r);
     void toQuat(Quat<T>& q) const;
 
+    Vec3 getBase(s32 axis) const;
+    Vec3 getRow(s32 row) const;
+
+    void getBase(Vec3& o, s32 axis) const;
+    void getRow(Vec3& o, s32 row) const;
+    void setBase(s32 axis, const Vec3& v);
+    void setRow(s32 row, const Vec3& v);
+
     static const Matrix33 zero;
     static const Matrix33 ident;
 };
@@ -173,6 +181,11 @@ public:
     void makeT(T x, T y, T z);
     void toQuat(QuatT& q) const;
 
+    Vec3 getBase(s32 axis) const;
+    Vec4 getRow(s32 row) const;
+    Vec3 getTranslation() const;
+    Vec3 getRotation() const;
+
     void getBase(Vec3& o, s32 axis) const;
     void getRow(Vec4& o, s32 row) const;
     void getTranslation(Vec3& o) const;
@@ -231,6 +244,9 @@ public:
     void makeRIdx(u32 xr, u32 yr, u32 zr);
     void makeRzxyIdx(u32 xr, u32 yr, u32 zr);
     void toQuat(Quat<T>& q) const;
+
+    Vec4 getCol(s32 axis) const;
+    Vec4 getRow(s32 row) const;
 
     void getCol(Vec4& o, s32 axis) const;
     void getRow(Vec4& o, s32 row) const;

--- a/include/math/seadMatrix.hpp
+++ b/include/math/seadMatrix.hpp
@@ -235,6 +235,46 @@ inline void Matrix33<T>::toQuat(Quat<T>& q) const
 }
 
 template <typename T>
+inline Vector3<T> Matrix33<T>::getBase(s32 axis) const
+{
+    Vec3 o;
+    Matrix33CalcCommon<T>::getBase(o, *this, axis);
+    return o;
+}
+
+template <typename T>
+inline Vector3<T> Matrix33<T>::getRow(s32 axis) const
+{
+    Vec3 o;
+    Matrix33CalcCommon<T>::getRow(o, *this, axis);
+    return o;
+}
+
+template <typename T>
+inline void Matrix33<T>::getBase(Vec3& o, s32 axis) const
+{
+    Matrix33CalcCommon<T>::getBase(o, *this, axis);
+}
+
+template <typename T>
+inline void Matrix33<T>::getRow(Vec4& o, s32 row) const
+{
+    Matrix33CalcCommon<T>::getRow(o, *this, row);
+}
+
+template <typename T>
+inline void Matrix33<T>::setBase(s32 axis, const Vec3& v)
+{
+    Matrix33CalcCommon<T>::setBase(*this, axis, v);
+}
+
+template <typename T>
+inline void Matrix33<T>::setRow(s32 row, const Vec3& v)
+{
+    Matrix33CalcCommon<T>::setRow(*this, v, row);
+}
+
+template <typename T>
 inline Matrix34<T>::Matrix34(T a00, T a01, T a02, T a03, T a10, T a11, T a12, T a13, T a20, T a21,
                              T a22, T a23)
 {
@@ -486,6 +526,38 @@ inline void Matrix34<T>::toQuat(QuatT& q) const
 }
 
 template <typename T>
+inline Vector3<T> Matrix34<T>::getBase(s32 axis) const
+{
+    Vec3 o;
+    Matrix34CalcCommon<T>::getBase(o, *this, axis);
+    return o;
+}
+
+template <typename T>
+inline Vector4<T> Matrix34<T>::getRow(s32 axis) const
+{
+    Vec4 o;
+    Matrix34CalcCommon<T>::getRow(o, *this, axis);
+    return o;
+}
+
+template <typename T>
+inline Vector3<T> Matrix34<T>::getTranslation(s32 axis) const
+{
+    Vec3 o;
+    Matrix34CalcCommon<T>::getTranslation(o, *this, axis);
+    return o;
+}
+
+template <typename T>
+inline Vector3<T> Matrix34<T>::getRotation(s32 axis) const
+{
+    Vec3 o;
+    Matrix34CalcCommon<T>::getRotation(o, *this, axis);
+    return o;
+}
+
+template <typename T>
 inline void Matrix34<T>::getBase(Vec3& o, s32 axis) const
 {
     Matrix34CalcCommon<T>::getBase(o, *this, axis);
@@ -678,6 +750,22 @@ template <typename T>
 inline void Matrix44<T>::toQuat(Quat<T>& q) const
 {
     Matrix44CalcCommon<T>::toQuat(q, *this);
+}
+
+template <typename T>
+inline Vector4<T> Matrix44<T>::getCol(s32 axis) const
+{
+    Vec4 o;
+    Matrix44CalcCommon<T>::getCol(o, *this, axis);
+    return o;
+}
+
+template <typename T>
+inline Vector4<T> Matrix44<T>::getRow(s32 axis) const
+{
+    Vec4 o;
+    Matrix44CalcCommon<T>::getRow(o, *this, axis);
+    return o;
 }
 
 template <typename T>

--- a/include/math/seadMatrixCalcCommon.h
+++ b/include/math/seadMatrixCalcCommon.h
@@ -56,6 +56,12 @@ public:
     static void makeSRIdx(Base& o, const Vec3& s, const Vector3<u32>& r);
     static void makeSRzxyIdx(Base& o, const Vec3& s, const Vector3<u32>& r);
     static void toQuat(Quat& q, const Base& n);
+
+    static void getBase(Vec3& v, const Base& n, s32 axis);
+    static void getRow(Vec3& v, const Base& n, s32 row);
+
+    static void setBase(Base& n, s32 axis, const Vec3& v);
+    static void setRow(Base& n, const Vec3& v, s32 row);
 };
 
 template <typename T>

--- a/include/math/seadMatrixCalcCommon.hpp
+++ b/include/math/seadMatrixCalcCommon.hpp
@@ -689,6 +689,38 @@ void Matrix33CalcCommon<T>::toQuat(Quat& q, const Base& n)
 }
 
 template <typename T>
+void Matrix33CalcCommon<T>::getBase(Vec3& v, const Base& n, s32 axis)
+{
+    v.x = n.m[0][axis];
+    v.y = n.m[1][axis];
+    v.z = n.m[2][axis];
+}
+
+template <typename T>
+void Matrix33CalcCommon<T>::getRow(Vec3& v, const Base& n, s32 row)
+{
+    v.x = n.m[row][0];
+    v.y = n.m[row][1];
+    v.z = n.m[row][2];
+}
+
+template <typename T>
+void Matrix33CalcCommon<T>::setBase(Base& n, s32 axis, const Vec3& v)
+{
+    n.m[0][axis] = v.x;
+    n.m[1][axis] = v.y;
+    n.m[2][axis] = v.z;
+}
+
+template <typename T>
+void Matrix33CalcCommon<T>::setRow(Base& n, const Vec3& v, s32 row)
+{
+    n.m[row][0] = v.x;
+    n.m[row][1] = v.y;
+    n.m[row][2] = v.z;
+}
+
+template <typename T>
 void Matrix34CalcCommon<T>::makeIdentity(Base& o)
 {
     Matrix34CalcCommon<T>::copy(o, Base{{{{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}}}});


### PR DESCRIPTION
Implements getBase, getRow, setBase and setRow for Matrix33 types required by `al::normalize`. <

It also adds overloads for the getters functions in Matrix33, Matrix34 and Matrix44. These overloads allow for much more intuitive coding like `f32 length=mtx.getBase(1).length();` which otherwise would require multiple lines to achieve the same thing.