### PR TITLE
Math: Fix Vector3::Rotate attempt 2

### DIFF
--- a/include/math/seadVectorCalcCommon.hpp
+++ b/include/math/seadVectorCalcCommon.hpp
@@ -170,12 +170,10 @@ inline void Vector3CalcCommon<T>::rotate(Base& o, const Quat& q, const Base& v)
     r.z = (q.x * v.y) - (q.y * v.x) + (q.w * v.z);
     r.w = -(q.x * v.x) - (q.y * v.y) - (q.z * v.z);
 
-    r.w *= -1;
-
-    // quat-multiplication
-    o.x = (q.w * r.x) - (q.z * r.y) + (q.y * r.z) + (q.x * r.w);
-    o.y = (q.z * r.x) + (q.w * r.y) - (q.x * r.z) + (q.y * r.w);
-    o.z = -(q.y * r.x) + (q.x * r.y) + (q.w * r.z) + (q.z * r.w);
+    // quat-multiplication with zero on o.w and everything is negated
+    o.x = (r.x * q.w) - (r.y * q.z) + (r.z * q.y) - (r.w * q.x);
+    o.y = (r.x * q.z) + (r.y * q.w) - (r.z * q.x) - (r.w * q.y);
+    o.z = -(r.x * q.y) + (r.y * q.x) + (r.z * q.w) - (r.w * q.z);
 }
 
 template <typename T>


### PR DESCRIPTION
Found by @Tomoeko this somehow still matches perfectly with the 5 instances of this function and fixes `al::rotateQuatLocalDirDegree` see https://decomp.me/scratch/pVSzv

I feel pretty confident that this is the true and final form of this function as both operations are exactly the same as seen more clearly with some additional spacing for the missing fields
```
    Quat r;  // quat-multiplication with 0 on w for v
    r.x =                (q.y * v.z) - (q.z * v.y) + (q.w * v.x);
    r.y = -(q.x * v.z) +               (q.z * v.x) + (q.w * v.y);
    r.z =  (q.x * v.y) - (q.y * v.x)               + (q.w * v.z);
    r.w = -(q.x * v.x) - (q.y * v.y) - (q.z * v.z);

    // quat-multiplication with zero on o.w and everything is negated
    o.x =  (r.x * q.w) - (r.y * q.z) + (r.z * q.y) - (r.w * q.x);
    o.y =  (r.x * q.z) + (r.y * q.w) - (r.z * q.x) - (r.w * q.y);
    o.z = -(r.x * q.y) + (r.y * q.x) + (r.z * q.w) - (r.w * q.z);
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/189)
<!-- Reviewable:end -->
