### PR TITLE
math: Add `Vector3::cross`

### DIFF
--- a/include/math/seadVector.h
+++ b/include/math/seadVector.h
@@ -135,6 +135,12 @@ struct Vector3 : public Policies<T>::Vec3Base
 
     Vector3 operator-() const { return {-this->x, -this->y, -this->z}; }
 
+    Vector3 cross(const Vector3& t) const {
+        Vector3 o;
+        o.setCross(*this, t);
+        return o;
+    }
+
     T dot(const Vector3& t) const;
     T length() const;
     T squaredLength() const;

--- a/include/math/seadVector.h
+++ b/include/math/seadVector.h
@@ -135,7 +135,8 @@ struct Vector3 : public Policies<T>::Vec3Base
 
     Vector3 operator-() const { return {-this->x, -this->y, -this->z}; }
 
-    Vector3 cross(const Vector3& t) const {
+    Vector3 cross(const Vector3& t) const
+    {
         Vector3 o;
         o.setCross(*this, t);
         return o;


### PR DESCRIPTION
Often, the pattern of first allocating a vector, then immediately assigning it to be a cross product can be observed.

With this change, the following two code snippets are equivalent:
```cpp
// old:
Vector3 result;
result->setCross(a, b);

// new:
Vector3 result = a.cross(b);
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/190)
<!-- Reviewable:end -->
