### PR TITLE
prim: Add unsafeCstr to SafeStringBase

### DIFF
--- a/include/prim/seadSafeString.h
+++ b/include/prim/seadSafeString.h
@@ -106,6 +106,8 @@ public:
         return mStringTop;
     }
 
+    const T* getStringTop() const { return mStringTop; }
+
     inline const T& at(s32 idx) const;
     inline const T& operator[](s32 idx) const { return at(idx); }
 


### PR DESCRIPTION
I don't know what to say but I need an unsafe version of cstr() because is required by al::ParameterObj::findParameter in SMO. Which I find in my opinion unusual to use a safe string and end up using non safe operations.

https://decomp.me/scratch/2yjeN

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/191)
<!-- Reviewable:end -->
