### PR TITLE
resource: Add header of `ParallelSZSDecompressor`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,7 @@ add_library(sead OBJECT
 
   include/resource/seadArchiveRes.h
   include/resource/seadDecompressor.h
+  include/resource/seadParallelSZSDecompressor.h
   include/resource/seadResource.h
   include/resource/seadResourceMgr.h
   include/resource/seadSharcArchiveRes.h

--- a/include/resource/seadParallelSZSDecompressor.h
+++ b/include/resource/seadParallelSZSDecompressor.h
@@ -5,7 +5,6 @@
 
 namespace sead
 {
-
 class ParallelSZSDecompressor : public Decompressor
 {
 public:

--- a/include/resource/seadParallelSZSDecompressor.h
+++ b/include/resource/seadParallelSZSDecompressor.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <mc/seadCoreInfo.h>
+#include <resource/seadDecompressor.h>
+
+namespace sead
+{
+
+class ParallelSZSDecompressor : public Decompressor
+{
+public:
+    ParallelSZSDecompressor(u32, s32, sead::Heap*, u8*, const CoreIdMask&);
+    ~ParallelSZSDecompressor() override;
+
+    u8* tryDecompFromDevice(const sead::ResourceMgr::LoadArg&, sead::Resource*, u32*, u32*,
+                            bool*) override;
+
+    void setDivSize(u32);
+
+private:
+    void* size[0x1a8 / 8];
+};
+
+static_assert(sizeof(ParallelSZSDecompressor) == 0x220);
+
+}  // namespace sead

--- a/include/resource/seadParallelSZSDecompressor.h
+++ b/include/resource/seadParallelSZSDecompressor.h
@@ -8,16 +8,17 @@ namespace sead
 class ParallelSZSDecompressor : public Decompressor
 {
 public:
-    ParallelSZSDecompressor(u32, s32, sead::Heap*, u8*, const CoreIdMask&);
+    ParallelSZSDecompressor(u32 workSize, s32 threadPriority, sead::Heap* heap, u8* workBuffer,
+                            const CoreIdMask& mask);
     ~ParallelSZSDecompressor() override;
 
-    u8* tryDecompFromDevice(const sead::ResourceMgr::LoadArg&, sead::Resource*, u32*, u32*,
-                            bool*) override;
+    u8* tryDecompFromDevice(const ResourceMgr::LoadArg& loadArg, Resource* resource, u32* outSize,
+                            u32* outAllocSize, bool* outAllocated) override;
 
     void setDivSize(u32);
 
 private:
-    void* size[0x1a8 / 8];
+    void* _78[0x1a8 / 8];
 };
 
 static_assert(sizeof(ParallelSZSDecompressor) == 0x220);


### PR DESCRIPTION
Variant of `SZSDecompressor` that is able to run in the background (using a separate `sead::Thread`). Needed by `al::SystemKit` in SMO, which (determined by the parameters given to the function) either constructs a `ParallelSZSDecompressor` or `SZSDecompressor`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/195)
<!-- Reviewable:end -->
