### PR TITLE
math: Add `Vector3::setAdd`

### DIFF
--- a/include/math/seadVector.h
+++ b/include/math/seadVector.h
@@ -167,6 +167,7 @@ struct Vector3 : public Policies<T>::Vec3Base
     void negate();
     void set(const Vector3& other);
     void set(T x, T y, T z);
+    void setAdd(const Vector3<T>& a, const Vector3<T>& b);
     void setCross(const Vector3<T>& a, const Vector3<T>& b);
     void setScale(const Vector3<T>& a, T t);
     void setScaleAdd(T t, const Vector3<T>& a, const Vector3<T>& b);

--- a/include/math/seadVector.hpp
+++ b/include/math/seadVector.hpp
@@ -273,6 +273,12 @@ inline void Vector3<T>::set(T x_, T y_, T z_)
 }
 
 template <typename T>
+inline void Vector3<T>::setAdd(const Vector3<T>& a, const Vector3<T>& b)
+{
+    Vector3CalcCommon<T>::add(*this, a, b);
+}
+
+template <typename T>
 inline void Vector3<T>::setCross(const Vector3<T>& a, const Vector3<T>& b)
 {
     Vector3CalcCommon<T>::cross(*this, a, b);


### PR DESCRIPTION
Pretty straight-forward - another function of this pattern is needed, apparently. The exact operation in question here is more like `setScaleAdd`, but has the two operands of the addition flipped - but it also matches when using `setAdd` and pre-scaling one of the arguments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/197)
<!-- Reviewable:end -->
