### PR TITLE
math: Fix `-Wunused-variable` in `seadMatrixCalcCommon.hpp`

### DIFF
--- a/include/math/seadMatrixCalcCommon.hpp
+++ b/include/math/seadMatrixCalcCommon.hpp
@@ -1830,8 +1830,8 @@ void Matrix34CalcCommon<T>::getRotation(Vec3& v, const Base& n)
     const T a13 = n.m[0][2];
 
     const T a21 = n.m[1][0];
-    const T a22 = n.m[1][1];
-    const T a23 = n.m[1][2];
+    // const T a22 = n.m[1][1];
+    // const T a23 = n.m[1][2];
 
     const T a31 = n.m[2][0];
     const T a32 = n.m[2][1];

--- a/include/math/seadMatrixCalcCommon.hpp
+++ b/include/math/seadMatrixCalcCommon.hpp
@@ -1830,8 +1830,6 @@ void Matrix34CalcCommon<T>::getRotation(Vec3& v, const Base& n)
     const T a13 = n.m[0][2];
 
     const T a21 = n.m[1][0];
-    // const T a22 = n.m[1][1];
-    // const T a23 = n.m[1][2];
 
     const T a31 = n.m[2][0];
     const T a32 = n.m[2][1];


### PR DESCRIPTION
These two variables are not needed by the computations below, so the compiler (rightfully) complains that these are not used afterwards. They can either be commented out (as done in this PR), or removed - please tell me if removing them entirely is preferred.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/198)
<!-- Reviewable:end -->
