### PR TITLE
heap: Add `HeapMgr::AllocFailedCallbackArg`

### DIFF
--- a/include/heap/seadHeapMgr.h
+++ b/include/heap/seadHeapMgr.h
@@ -25,7 +25,13 @@ class HeapMgr : hostio::Node
     using IFreeCallback = IDelegate1<const FreeCallbackArg*>;
 
 public:
-    struct AllocFailedCallbackArg;
+    struct AllocFailedCallbackArg {
+        Heap* heap;
+        size_t request_size;
+        s32 request_alignment;
+        size_t alloc_size;
+        s32 alloc_alignment;
+    };
     using IAllocFailedCallback = IDelegate1<const AllocFailedCallbackArg*>;
 
     HeapMgr();


### PR DESCRIPTION
Required for some heap management utilities in SMO, which overrides the `sead::HeapMgr::mAllocFailedCallback`, providing a custom implementation for that failure - which just decides to ignore them if the heap is called `gpu`.

This code was taken from https://github.com/stupidestmodder/sead/blob/dcaf208d6c6c5b482f19851262e360bc4d1d3955/sead/include/heap/seadHeapMgr.h#L31-L38