### PR TITLE
Move some incorrectly placed empty virtual dtors into cpp

### DIFF
--- a/include/gfx/seadCamera.h
+++ b/include/gfx/seadCamera.h
@@ -49,7 +49,7 @@ class LookAtCamera : public Camera
 public:
     LookAtCamera() = default;
     LookAtCamera(const Vector3f& pos, const Vector3f& at, const Vector3f& up);
-    ~LookAtCamera() override = default;
+    ~LookAtCamera() override;
 
     void doUpdateMatrix(Matrix34f* dst) const override;
 
@@ -79,7 +79,7 @@ class DirectCamera : public Camera
 {
     SEAD_RTTI_OVERRIDE(DirectCamera, Camera)
 public:
-    virtual ~DirectCamera();
+    ~DirectCamera() override;
 
     void doUpdateMatrix(Matrix34f* dst) const override;
 

--- a/include/heap/seadHeapMgr.h
+++ b/include/heap/seadHeapMgr.h
@@ -29,7 +29,7 @@ public:
     using IAllocFailedCallback = IDelegate1<const AllocFailedCallbackArg*>;
 
     HeapMgr();
-    virtual ~HeapMgr() {}
+    virtual ~HeapMgr();
 
     static void initialize(size_t size);
     static void initializeImpl_();

--- a/modules/src/gfx/seadCamera.cpp
+++ b/modules/src/gfx/seadCamera.cpp
@@ -5,10 +5,17 @@ namespace sead
 {
 Camera::~Camera() = default;
 
+LookAtCamera::~LookAtCamera() = default;
+
 LookAtCamera::LookAtCamera(const Vector3f& pos, const Vector3f& at, const Vector3f& up)
     : mPos(pos), mAt(at), mUp(up)
 {
     SEAD_ASSERT(mPos != mAt);
     mUp.normalize();
 }
+
+OrthoCamera::~OrthoCamera() = default;
+
+DirectCamera::~DirectCamera() = default;
+
 }  // namespace sead

--- a/modules/src/heap/seadHeapMgr.cpp
+++ b/modules/src/heap/seadHeapMgr.cpp
@@ -17,6 +17,7 @@ HeapMgr::IndependentHeaps HeapMgr::sIndependentHeaps;
 CriticalSection HeapMgr::sHeapTreeLockCS;
 
 HeapMgr::HeapMgr() = default;
+HeapMgr::~HeapMgr() = default;
 
 void HeapMgr::initialize(size_t size)
 {


### PR DESCRIPTION
While developing a new version of `viking` that uses a new file list format instead of the function csv, I noticed that some `sead` related symbols that aren't marked as weak in the 1.0 smo executable were marked as weak in the decomp elf. When using clang, if a function is a **header defined** virtual, it always gets weak linkage (marked with `W` when using `llvm-nm`) but these functions are marked with `T` in the smo executable, which means they were placed into the cpp by the devs. For this reason I've moved them there which also matches some `sead` RTTI related functions in these classes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/200)
<!-- Reviewable:end -->
