### PR TITLE
container: Modify compareT of PtrArray and ObjArray to allow class specific implementations, add ConstPtrArray placeholder

### DIFF
--- a/include/container/seadObjArray.h
+++ b/include/container/seadObjArray.h
@@ -236,7 +236,10 @@ protected:
         return new (storage) T(item);
     }
 
-    static s32 compareT(const void* a, const void* b) { return compareT((const T*)a, (const T*)b); }
+    static s32 compareT(const void* a, const void* b)
+    {
+        return compareT(static_cast<const T*>(a), static_cast<const T*>(b));
+    }
 
     static s32 compareT(const T* a, const T* b)
     {

--- a/include/container/seadPtrArray.h
+++ b/include/container/seadPtrArray.h
@@ -347,7 +347,10 @@ protected:
         return static_cast<void*>(const_cast<std::remove_const_t<T>*>(ptr));
     }
 
-    static s32 compareT(const void* a, const void* b) { return compareT((const T*)a, (const T*)b); }
+    static s32 compareT(const void* a, const void* b)
+    {
+        return compareT(static_cast<const T*>(a), static_cast<const T*>(b));
+    }
 
     static s32 compareT(const T* a, const T* b)
     {
@@ -377,7 +380,7 @@ private:
     T* mWork[N];
 };
 
-// TODO: Restrict calls this object type
+// TODO: Restrict usage of this object type
 template <typename T>
 class ConstPtrArray : public PtrArray<T>
 {


### PR DESCRIPTION
SMO has custom implementations of compareT for both array types. Like:

- `sead::PtrArray<FukuwaraiFaceParts>::compareT(FukuwaraiFaceParts const*, FukuwaraiFaceParts const*)`
- `sead::PtrArray<al::TextureInfo>::compareT(al::TextureInfo const*, al::TextureInfo const*)`
- `sead::ObjArray<al::Graph::VertexInfo>::compareT(al::Graph::VertexInfo const*, al::Graph::VertexInfo const*)`

These implementations can't be done with the current function definition. 

Additionally `ConstPtrArray` seems to ve a variant of the regular PtrArray. I don't have any details about this class other than the regular function calls match PtrArray. Required by a couple of functions like `al::findEdgeMinimumWeight(al::Graph::Edge const**, sead::ConstPtrArray<al::Graph::Edge> const&)`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/202)
<!-- Reviewable:end -->
