### PR TITLE
container: Fix `PtrArrayImpl::popBack`

### DIFF
--- a/include/container/seadPtrArray.h
+++ b/include/container/seadPtrArray.h
@@ -86,7 +86,8 @@ protected:
 
     void pushFront(void* ptr) { insert(0, ptr); }
 
-    void* popBack() {
+    void* popBack()
+    {
         if (mPtrNum >= 1)
             return mPtrs[--mPtrNum];
         return nullptr;

--- a/include/container/seadPtrArray.h
+++ b/include/container/seadPtrArray.h
@@ -86,7 +86,11 @@ protected:
 
     void pushFront(void* ptr) { insert(0, ptr); }
 
-    void* popBack() { return isEmpty() ? nullptr : mPtrs[--mPtrNum]; }
+    void* popBack() {
+        if (mPtrNum >= 1)
+            return mPtrs[--mPtrNum];
+        return nullptr;
+    }
 
     void* popFront()
     {

--- a/modules/src/heap/seadHeapMgr.cpp
+++ b/modules/src/heap/seadHeapMgr.cpp
@@ -47,7 +47,6 @@ void HeapMgr::createRootHeap_()
     sRootHeaps.pushBack(expHeap);
 }
 
-// NON_MATCHING: mismatching on the loops, maybe due to an issue in popBack
 void HeapMgr::destroy()
 {
     sHeapTreeLockCS.lock();


### PR DESCRIPTION
This pull request changes `sead::PtrArrayImpl::popBack` to match SMO.

Notes:
* The `popBack` method is inlined, so there’s nothing to match with _directly_.
* This PR fixes `sead::HeapMgr::destroy` which was previous mismatching.
* This PR is a prerequisite for matching `PlayerBindableSensorList` (see [OdysseyDecomp#181](https://github.com/MonsterDruide1/OdysseyDecomp/pull/181)) which uses the `popBack` method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/203)
<!-- Reviewable:end -->
