### PR TITLE
math: Implement `BoundBox::setIncludePoint`

### DIFF
--- a/include/math/seadBoundBox.h
+++ b/include/math/seadBoundBox.h
@@ -84,6 +84,7 @@ struct BoundBox3
     void setUndef();
     void set(T x0, T y0, T z0, T x1, T y1, T z1);
     void set(const Vector3& min, const Vector3& max);
+    void setIncludePoint(const Vector3& p);
     void setMin(const Vector3& min);
     void setMax(const Vector3& max);
     void offset(T dx, T dy, T dz);

--- a/include/math/seadBoundBox.h
+++ b/include/math/seadBoundBox.h
@@ -84,9 +84,9 @@ struct BoundBox3
     void setUndef();
     void set(T x0, T y0, T z0, T x1, T y1, T z1);
     void set(const Vector3& min, const Vector3& max);
-    void setIncludePoint(const Vector3& p);
     void setMin(const Vector3& min);
     void setMax(const Vector3& max);
+    void addPoint(const Vector3& p);
     void offset(T dx, T dy, T dz);
     void offset(const Vector3& dv);
     void scaleX(T sx);

--- a/include/math/seadBoundBox.hpp
+++ b/include/math/seadBoundBox.hpp
@@ -221,6 +221,17 @@ inline void BoundBox3<T>::set(const Vector3& min, const Vector3& max)
 }
 
 template <typename T>
+inline void BoundBox3<T>::setIncludePoint(const Vector3& p)
+{
+    if (mMin.x > p.x) mMin.x = p.x;
+    if (mMin.y > p.y) mMin.y = p.y;
+    if (mMin.z > p.z) mMin.z = p.z;
+    if (mMax.x < p.x) mMax.x = p.x;
+    if (mMax.y < p.y) mMax.y = p.y;
+    if (mMax.z < p.z) mMax.z = p.z;
+}
+
+template <typename T>
 inline void BoundBox3<T>::setMin(const Vector3& min)
 {
     mMin = min;

--- a/include/math/seadBoundBox.hpp
+++ b/include/math/seadBoundBox.hpp
@@ -221,17 +221,6 @@ inline void BoundBox3<T>::set(const Vector3& min, const Vector3& max)
 }
 
 template <typename T>
-inline void BoundBox3<T>::setIncludePoint(const Vector3& p)
-{
-    if (mMin.x > p.x) mMin.x = p.x;
-    if (mMin.y > p.y) mMin.y = p.y;
-    if (mMin.z > p.z) mMin.z = p.z;
-    if (mMax.x < p.x) mMax.x = p.x;
-    if (mMax.y < p.y) mMax.y = p.y;
-    if (mMax.z < p.z) mMax.z = p.z;
-}
-
-template <typename T>
 inline void BoundBox3<T>::setMin(const Vector3& min)
 {
     mMin = min;
@@ -241,6 +230,23 @@ template <typename T>
 inline void BoundBox3<T>::setMax(const Vector3& max)
 {
     mMax = max;
+}
+
+template <typename T>
+inline void BoundBox3<T>::addPoint(const Vector3& p)
+{
+    if (mMin.x > p.x)
+        mMin.x = p.x;
+    if (mMin.y > p.y)
+        mMin.y = p.y;
+    if (mMin.z > p.z)
+        mMin.z = p.z;
+    if (mMax.x < p.x)
+        mMax.x = p.x;
+    if (mMax.y < p.y)
+        mMax.y = p.y;
+    if (mMax.z < p.z)
+        mMax.z = p.z;
 }
 
 template <typename T>


### PR DESCRIPTION
This function is used by `CollisionDirector::checkStrikeArrow` within SMO. It accepts a point and (if necessary) adjusts the `mMin` and `mMax` of the `BoundBox`, so it includes this point as well. In the aforementioned function, it is called twice to set up a previously uninitialized BoundBox - this codegen cannot be reproduced with existing functions. The function name is totally made-up, so I'm happy to take suggestions on that as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/204)
<!-- Reviewable:end -->
