### PR TITLE
container: Early-abort on failed `StrTreeMap::allocBuffer`

### DIFF
--- a/include/container/seadStrTreeMap.h
+++ b/include/container/seadStrTreeMap.h
@@ -81,6 +81,7 @@ inline void StrTreeMap<N, Value>::allocBuffer(s32 node_max, Heap* heap, s32 alig
     {
         SEAD_ASSERT_MSG(false, "node_max[%d] must be larger than zero", node_max);
         AllocFailAssert(heap, node_max * node_size, alignment);
+        return;
     }
 
     void* work = AllocBuffer(node_max * node_size, heap, alignment);


### PR DESCRIPTION
Required to match `al::ActorResourceHolder::ActorResourceHolder(int)` in SMO.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/206)
<!-- Reviewable:end -->
