### PR TITLE
prim/SafeString: Add `WFixedSafeString::operator=`

### DIFF
--- a/include/prim/seadSafeString.h
+++ b/include/prim/seadSafeString.h
@@ -394,6 +394,18 @@ public:
     WFixedSafeString() : FixedSafeStringBase<char16, L>() {}
 
     WFixedSafeString(const WSafeString& str) : FixedSafeStringBase<char16, L>(str) {}
+
+    WFixedSafeString& operator=(const WFixedSafeString& other)
+    {
+        this->copy(other);
+        return *this;
+    }
+
+    WFixedSafeString& operator=(const WSafeString& other) SEAD_SAFESTRING_OVERRIDE_TOKEN
+    {
+        this->copy(other);
+        return *this;
+    }
 };
 
 template <s32 L>


### PR DESCRIPTION
Here, I'm adding the same two overrides for `WFixedSafeString` as already exist for `FixedSafeString`. At least the bottom one needs to exist, as the associated symbol listed in SMO cannot be generated otherwise. I do not have any proof/indication that the first (non-virtual function) exists, but I added it anyways for consistency with other `sead::SafeString`-types.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/209)
<!-- Reviewable:end -->
