### PR TITLE
mc/CoreInfo: Fix `CoreInfo::configure` to match

### DIFF
--- a/modules/src/mc/seadCoreInfo.cpp
+++ b/modules/src/mc/seadCoreInfo.cpp
@@ -45,7 +45,7 @@ void CoreInfo::configure()
     const auto alloc_result = nn::os::AllocateTlsSlot(&sCoreNumberTlsSlot, nullptr);
     SEAD_ASSERT(alloc_result.IsSuccess());
 
-    for (u32 i = 0; i != sNumCores; ++i)
+    for (size_t i = 0; i != sNumCores; ++i)
     {
         const u32 id = sPlatformCoreId[i];
         sCoreIdFromPlatformCoreIdTable[id] = i;


### PR DESCRIPTION
A few instructions were wrongly using `w`-registers instead of `x` here. Changing the loop iterator type fixes these mismatches, allowing `CoreInfo::configure` and the auto-generated file initializer function to match.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/210)
<!-- Reviewable:end -->
