### PR TITLE
framework: Implement `TaskBase::CreateArg`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ add_library(sead OBJECT
   modules/src/framework/seadGameFramework.cpp
   modules/src/framework/seadMethodTree.cpp
   modules/src/framework/seadProcessMeterBar.cpp
+  modules/src/framework/seadTaskBase.cpp
   modules/src/framework/seadTaskMgr.cpp
 
   include/gfx/nvn/seadDebugFontMgrNvn.h

--- a/include/framework/seadTaskBase.h
+++ b/include/framework/seadTaskBase.h
@@ -49,19 +49,22 @@ public:
 
     struct CreateArg
     {
+        CreateArg();
+        CreateArg(const TaskClassID& factory);
+
         typedef void (*SingletonFunc)(TaskBase*);
 
         TaskClassID factory;
         HeapPolicies heap_policies;
-        TaskBase* parent;
-        TaskParameter* parameter;
-        FaderTaskBase* fader;
-        TaskBase* src_task;
-        TaskBase** created_task;
-        DelegateEvent<TaskBase*>::Slot* create_callback;
+        TaskBase* parent = nullptr;
+        TaskParameter* parameter = nullptr;
+        FaderTaskBase* fader = nullptr;
+        TaskBase* src_task = nullptr;
+        TaskBase** created_task = nullptr;
+        DelegateEvent<TaskBase*>::Slot* create_callback = nullptr;
         TaskUserID user_id;
-        Tag tag;
-        SingletonFunc instance_cb;
+        Tag tag = cApp;
+        SingletonFunc instance_cb = nullptr;
     };
 
 public:

--- a/include/framework/seadTaskID.h
+++ b/include/framework/seadTaskID.h
@@ -24,7 +24,7 @@ typedef TaskBase* (*TaskFactory)(const TaskConstructArg&);
 class TaskClassID
 {
 public:
-    enum Type : u64
+    enum Type : u32
     {
         cInvalid = 0,
         cInt = 1,
@@ -33,19 +33,19 @@ public:
     };
 
 public:
-    Type mType;
+    Type mType = cInvalid;
     union
     {
         s32 mInt;
         TaskFactory mFactory;
-        const char* mString;
+        const char* mString = nullptr;
     } mID;
 };
 
 class TaskUserID
 {
 public:
-    s32 mID;
+    s32 mID = -1;
 };
 
 }  // namespace sead

--- a/modules/src/framework/seadTaskBase.cpp
+++ b/modules/src/framework/seadTaskBase.cpp
@@ -1,0 +1,8 @@
+#include "framework/seadTaskBase.h"
+
+namespace sead
+{
+TaskBase::CreateArg::CreateArg() = default;
+
+TaskBase::CreateArg::CreateArg(const TaskClassID& factory) : factory(factory) {}
+}  // namespace sead


### PR DESCRIPTION
Mostly done by specifying some default members of the class.

Other than that, the type of `TaskClassID::Type` has been changed from `u64` to `u32` to match the instructions accessing it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/212)
<!-- Reviewable:end -->
