### PR TITLE
`Matrix34`: Add `operator*=`

### DIFF
--- a/include/math/seadMatrix.h
+++ b/include/math/seadMatrix.h
@@ -153,6 +153,17 @@ public:
         result.setMul(lhs, rhs);
         return result;
     }
+    friend Self operator*=(Self& lhs, const Self& rhs)
+    {
+        lhs = lhs * rhs;
+        return lhs;
+    }
+    friend Self operator*=(Mtx33& lhs, const Self& rhs)
+    {
+        lhs = lhs * rhs;
+        return lhs * rhs;
+    }
+
     void setMul(const Self& a, const Self& b);
     void setMul(const Mtx33& a, const Self& b);
 


### PR DESCRIPTION
This PR adds two `operator*=`s to `Matrix34` that just use the two existing `operator*`. This helps make code that has matrix multiplication a tiny bit cleaner since `a = a * b` can now be written as `a *= b`