### PR TITLE
math: Fix Quat multiplication and implement squaredLength, add, sub

### DIFF
--- a/include/math/seadQuat.h
+++ b/include/math/seadQuat.h
@@ -29,32 +29,41 @@ public:
         return *this;
     }
 
-    friend Quat operator*(const Quat& a, T t)
+    Quat& operator+=(const Quat& other);
+    friend Quat operator+(const Quat& a, const Quat& b)
     {
-        auto result = a;
-        result *= t;
-        return result;
+        Quat o;
+        QuatCalcCommon<T>::add(o, a, b);
+        return o;
+    }
+
+    Quat& operator-=(const Quat& other);
+    friend Quat operator-(const Quat& a, const Quat& b)
+    {
+        Quat o;
+        QuatCalcCommon<T>::sub(o, a, b);
+        return o;
+    }
+
+    friend Quat operator*(const Quat& q, T t)
+    {
+        Quat o;
+        QuatCalcCommon<T>::setMulScalar(o, q, t);
+        return o;
     }
 
     friend Quat operator*(const Quat& a, const Quat& b)
     {
-        auto result = a;
-        result *= b;
-        return result;
+        Quat o;
+        QuatCalcCommon<T>::setMul(o, a, b);
+        return o;
     }
 
-    friend Quat operator*(T t, const Quat& a) { return operator*(a, t); }
+    friend Quat operator*(T t, const Quat& q) { return operator*(q, t); }
 
     Quat& operator*=(const Quat& t);
 
-    Quat& operator*=(T t)
-    {
-        this->w *= t;
-        this->x *= t;
-        this->y *= t;
-        this->z *= t;
-        return *this;
-    }
+    Quat& operator*=(T t);
 
     bool operator==(const Quat& rhs) const
     {
@@ -62,6 +71,7 @@ public:
     }
 
     T length() const;
+    T squaredLength() const;
     T normalize();
     T dot(const Self& q);
     void inverse(Self* q);
@@ -71,6 +81,8 @@ public:
     void set(const Self& other);
     void set(T w, T x, T y, T z);
     void setRPY(T roll, T pitch, T yaw);
+    void setAdd(const Quat& a, const Quat& b);
+    void setSub(const Quat& a, const Quat& b);
     void calcRPY(Vec3& rpy) const;
 
     static const Quat unit;

--- a/include/math/seadQuat.hpp
+++ b/include/math/seadQuat.hpp
@@ -14,9 +14,30 @@ inline Quat<T>::Quat(T w_, T x_, T y_, T z_)
 }
 
 template <typename T>
-inline Quat<T>& Quat<T>::operator*=(const Quat<T>& t)
+inline Quat<T>& Quat<T>::operator+=(const Quat<T>& other)
 {
-    QuatCalcCommon<T>::setMul(*this, *this, t);
+    QuatCalcCommon<T>::add(*this, *this, other);
+    return *this;
+}
+
+template <typename T>
+inline Quat<T>& Quat<T>::operator-=(const Quat<T>& other)
+{
+    QuatCalcCommon<T>::sub(*this, *this, other);
+    return *this;
+}
+
+template <typename T>
+inline Quat<T>& Quat<T>::operator*=(const Quat<T>& other)
+{
+    QuatCalcCommon<T>::setMul(*this, *this, other);
+    return *this;
+}
+
+template <typename T>
+inline Quat<T>& Quat<T>::operator*=(T other)
+{
+    QuatCalcCommon<T>::setMulScalar(*this, *this, other);
     return *this;
 }
 
@@ -24,6 +45,12 @@ template <typename T>
 inline T Quat<T>::length() const
 {
     return QuatCalcCommon<T>::length(*this);
+}
+
+template <typename T>
+inline T Quat<T>::squaredLength() const
+{
+    return QuatCalcCommon<T>::squaredLength(*this);
 }
 
 template <typename T>
@@ -89,6 +116,18 @@ template <typename T>
 inline void Quat<T>::setRPY(T roll, T pitch, T yaw)
 {
     QuatCalcCommon<T>::setRPY(*this, roll, pitch, yaw);
+}
+
+template <typename T>
+inline void Quat<T>::setAdd(const Quat<T>& a, const Quat<T>& b)
+{
+    QuatCalcCommon<T>::add(*this, a, b);
+}
+
+template <typename T>
+inline void Quat<T>::setSub(const Quat<T>& a, const Quat<T>& b)
+{
+    QuatCalcCommon<T>::sub(*this, a, b);
 }
 
 template <typename T>

--- a/include/math/seadQuatCalcCommon.h
+++ b/include/math/seadQuatCalcCommon.h
@@ -13,9 +13,14 @@ public:
     using Vec3 = typename Policies<T>::Vec3Base;
 
     static T length(const Base& v);
+    static T squaredLength(const Base& v);
     static T normalize(Base& v);
     static T dot(const Base& u, const Base& v);
+
+    static void add(Base& out, const Base& a, const Base& b);
+    static void sub(Base& out, const Base& a, const Base& b);
     static void setMul(Base& out, const Base& u, const Base& v);
+    static void setMulScalar(Base& out, const Base& q, T t);
     static void slerpTo(Base& out, const Base& q1, const Base& q2, f32 t);
     static void makeUnit(Base& q);
     static bool makeVectorRotation(Base& q, const Vec3& from, const Vec3& to);

--- a/include/math/seadQuatCalcCommon.hpp
+++ b/include/math/seadQuatCalcCommon.hpp
@@ -13,7 +13,13 @@ namespace sead
 template <typename T>
 inline T QuatCalcCommon<T>::length(const Base& v)
 {
-    return std::sqrt(dot(v, v));
+    return MathCalcCommon<T>::sqrt(squaredLength(v));
+}
+
+template <typename T>
+inline T QuatCalcCommon<T>::squaredLength(const Base& v)
+{
+    return (v.w * v.w) + (v.x * v.x) + (v.y * v.y) + (v.z * v.z);
 }
 
 template <typename T>
@@ -39,6 +45,24 @@ inline T QuatCalcCommon<T>::dot(const Base& u, const Base& v)
 }
 
 template <typename T>
+inline void QuatCalcCommon<T>::add(Base& out, const Base& a, const Base& b)
+{
+    out.w = a.w + b.w;
+    out.x = a.x + b.x;
+    out.y = a.y + b.y;
+    out.z = a.z + b.z;
+}
+
+template <typename T>
+inline void QuatCalcCommon<T>::sub(Base& out, const Base& a, const Base& b)
+{
+    out.w = a.w - b.w;
+    out.x = a.x - b.x;
+    out.y = a.y - b.y;
+    out.z = a.z - b.z;
+}
+
+template <typename T>
 inline void QuatCalcCommon<T>::setMul(Base& out, const Base& u, const Base& v)
 {
     T w = (u.w * v.w) - (u.x * v.x) - (u.y * v.y) - (u.z * v.z);
@@ -49,6 +73,15 @@ inline void QuatCalcCommon<T>::setMul(Base& out, const Base& u, const Base& v)
     out.x = x;
     out.y = y;
     out.z = z;
+}
+
+template <typename T>
+inline void QuatCalcCommon<T>::setMulScalar(Base& out, const Base& q, T t)
+{
+    out.w = q.w * t;
+    out.x = q.x * t;
+    out.y = q.y * t;
+    out.z = q.z * t;
 }
 
 template <typename T>


### PR DESCRIPTION
Lately I been dealing with a lot of quat operations. So I decided to address them and implement a few basic operations that are commonly used. Currently the biggest issue is that these 3 operations aren't the same.
`quatUp = quatUp * al::getQuat(this);`
`quatUp *= al::getQuat(this);`
`sead::QuatCalcCommon<f32>::setMul(quatUp, quatUp, al::getQuat(this));`

With some matches starting to have some unexpected code

```
    sead::Quatf quat;
    al::makeQuatRotationRate(&quat, updir2, mUpDir, 1.0f);
    {
        sead::Quatf quat1;
        sead::QuatCalcCommon<f32>::setMul(quat1, quat, al::getQuat(this));
        al::setQuat(this, quat1);
    }

    sead::Quatf quat2;
    al::makeQuatRotationRate(&quat2, mUpDir, mFireSurface, 0.1f);
    {
        sead::Quatf quat5;
        sead::QuatCalcCommon<f32>::setMul(quat5, quat2, al::getQuat(this));
        al::setQuat(this, quat5);
    }
    
      sead::Quatf x;
      sead::QuatCalcCommon<f32>::setMul(x, quat, newQuat);
      quat = quat * quatC;
```

After this PR no mismatches were generated and a previously mismatched function was fixed. The code now looks like something a regular developer will do
```
    sead::Quatf quat;
    al::makeQuatRotationRate(&quat, updir2, mUpDir, 1.0f);
    al::setQuat(this, quat * al::getQuat(this));

    sead::Quatf quat2;
    al::makeQuatRotationRate(&quat2, mUpDir, mFireSurface, 0.1f);
    al::setQuat(this, quat2 * al::getQuat(this));
    
    quat = quat * newQuat * quatC;
```

