### PR TITLE
math: Fix floor to int

### DIFF
--- a/include/math/seadMathCalcCommon.hpp
+++ b/include/math/seadMathCalcCommon.hpp
@@ -441,7 +441,12 @@ inline s32 MathCalcCommon<s32>::roundOff(s32 val)
 template <typename T>
 inline s32 MathCalcCommon<T>::floor(T val)
 {
-    return std::floor(val);
+    s32 x = static_cast<s32>(val);
+
+    if (x == val)
+        return x;
+
+    return x + (val >= 0 ? 0 : -1);
 }
 
 template <>


### PR DESCRIPTION
It appears that this math operation doesn't use std since that generates a single `fcvtms` operation. Instead it done manually in the library. 

The main motivation is that we have a couple of cases were the same pattern repeats, all doing something similar to a floor operation like:
```
  iVar2 = 0;
  if ((float)(int)fVar4 != fVar4) {
    iVar2 = -(uint)(fVar4 < 0.0);
  }
  uVar1 = iVar2 + (int)fVar4;
```
https://github.com/MonsterDruide1/OdysseyDecomp/blob/master/src/Npc/BigBirdStateWait.cpp#L49
https://github.com/MonsterDruide1/OdysseyDecomp/blob/master/lib/al/Library/Math/MathUtil.cpp#L504
BubbleStateInLauncher::exeShoot
BubbleStateInLauncher::calcLaunchPos
BigBirdStateWait::exeWaitRight
alSeFunction::updateSeParamListWithResInfo
agl::pfx::ColorCorrection::calcRGB_
agl::sdw::DepthShadowUnit::updateShadowViewProjection_
agl::sdw::DepthShadowUnit::adjustTexelStable