### PR TITLE
math: Add `Vector2::setAdd`

### DIFF
--- a/include/math/seadVector.h
+++ b/include/math/seadVector.h
@@ -59,6 +59,7 @@ struct Vector2 : public Policies<T>::Vec2Base
     void negate();
     void set(const Vector2& other);
     void set(T x_, T y_);
+    void setAdd(const Vector2<T>& a, const Vector2<T>& b);
     void setScale(const Vector2<T>& a, T t);
 
     T dot(const Vector2& other) const;

--- a/include/math/seadVector.hpp
+++ b/include/math/seadVector.hpp
@@ -76,6 +76,12 @@ inline void Vector2<T>::set(T x_, T y_)
 }
 
 template <typename T>
+inline void Vector2<T>::setAdd(const Vector2<T>& a, const Vector2<T>& b)
+{
+    Vector2CalcCommon<T>::add(*this, a, b);
+}
+
+template <typename T>
 inline void Vector2<T>::setScale(const Vector2<T>& a, T t)
 {
     Vector2CalcCommon<T>::multScalar(*this, a, t);


### PR DESCRIPTION
Similar to what `Vector3::setAdd` already implements. Results in slightly less optimal codegen (ldr, add, str ; ldr, add, str), which is sometimes desired to match a function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/218)
<!-- Reviewable:end -->
