### PR TITLE
Fix(sead): Fix roundUp, roundUpPow2, roundDownN and roundDownPow2 signatures

### DIFF
--- a/include/math/seadMathCalcCommon.h
+++ b/include/math/seadMathCalcCommon.h
@@ -129,10 +129,10 @@ public:
     static s32 roundOff(T);
     static s32 floor(T);
     static s32 ceil(T);
-    static T roundUp(T x, s32 multNumber);
-    static s32 roundUpPow2(T x, s32 y);
-    static s32 roundDownN(T val, s32 multNumber);
-    static s32 roundDownPow2(T x, s32 y);
+    static T roundUp(T x, u32 multNumber);
+    static s32 roundUpPow2(T x, u32 y);
+    static s32 roundDownN(T val, u32 multNumber);
+    static s32 roundDownPow2(T x, u32 y);
     static T clampMax(T val, T max_);
     static T clampMin(T val, T min_);
     static T clamp(T value, T low, T high);

--- a/include/math/seadMathCalcCommon.hpp
+++ b/include/math/seadMathCalcCommon.hpp
@@ -468,21 +468,21 @@ inline s32 MathCalcCommon<s32>::ceil(s32 val)
 }
 
 template <typename T>
-inline T MathCalcCommon<T>::roundUp(T x, s32 multNumber)
+inline T MathCalcCommon<T>::roundUp(T x, u32 multNumber)
 {
     SEAD_ASSERT(multNumber > 0);
     return (x + multNumber - 1) / multNumber * multNumber;
 }
 
 template <>
-inline s32 MathCalcCommon<u32>::roundUpPow2(u32 val, s32 base)
+inline s32 MathCalcCommon<u32>::roundUpPow2(u32 val, u32 base)
 {
     SEAD_ASSERT_MSG((u32(base - 1) & u32(base)) == 0, "illegal param[val:%d, base:%d]", val, base);
     return (val + base - 1) & (u32)-base;
 }
 
 template <>
-inline s32 MathCalcCommon<s32>::roundUpPow2(s32 val, s32 base)
+inline s32 MathCalcCommon<s32>::roundUpPow2(s32 val, u32 base)
 {
     SEAD_ASSERT_MSG(val >= 0 && (u32(base - 1) & u32(base)) == 0, "illegal param[val:%d, base:%d]",
                     val, base);

--- a/include/math/seadMathCalcCommon.hpp
+++ b/include/math/seadMathCalcCommon.hpp
@@ -484,8 +484,8 @@ inline s32 MathCalcCommon<u32>::roundUpPow2(u32 val, u32 base)
 template <>
 inline s32 MathCalcCommon<s32>::roundUpPow2(s32 val, u32 base)
 {
-    SEAD_ASSERT_MSG(val >= 0 && ((base - 1) & base) == 0, "illegal param[val:%d, base:%d]",
-                    val, base);
+    SEAD_ASSERT_MSG(val >= 0 && ((base - 1) & base) == 0, "illegal param[val:%d, base:%d]", val,
+                    base);
     return (val + base - 1) & ~(base - 1);
 }
 

--- a/include/math/seadMathCalcCommon.hpp
+++ b/include/math/seadMathCalcCommon.hpp
@@ -477,16 +477,16 @@ inline T MathCalcCommon<T>::roundUp(T x, u32 multNumber)
 template <>
 inline s32 MathCalcCommon<u32>::roundUpPow2(u32 val, u32 base)
 {
-    SEAD_ASSERT_MSG((u32(base - 1) & u32(base)) == 0, "illegal param[val:%d, base:%d]", val, base);
-    return (val + base - 1) & (u32)-base;
+    SEAD_ASSERT_MSG(((base - 1) & base) == 0, "illegal param[val:%d, base:%d]", val, base);
+    return (val + base - 1) & -base;
 }
 
 template <>
 inline s32 MathCalcCommon<s32>::roundUpPow2(s32 val, u32 base)
 {
-    SEAD_ASSERT_MSG(val >= 0 && (u32(base - 1) & u32(base)) == 0, "illegal param[val:%d, base:%d]",
+    SEAD_ASSERT_MSG(val >= 0 && ((base - 1) & base) == 0, "illegal param[val:%d, base:%d]",
                     val, base);
-    return (val + base - 1) & (u32)-base;
+    return (val + base - 1) & -base;
 }
 
 template <typename T>

--- a/include/math/seadMathCalcCommon.hpp
+++ b/include/math/seadMathCalcCommon.hpp
@@ -478,7 +478,7 @@ template <>
 inline s32 MathCalcCommon<u32>::roundUpPow2(u32 val, u32 base)
 {
     SEAD_ASSERT_MSG(((base - 1) & base) == 0, "illegal param[val:%d, base:%d]", val, base);
-    return (val + base - 1) & -base;
+    return (val + base - 1) & ~(base - 1);
 }
 
 template <>
@@ -486,7 +486,7 @@ inline s32 MathCalcCommon<s32>::roundUpPow2(s32 val, u32 base)
 {
     SEAD_ASSERT_MSG(val >= 0 && ((base - 1) & base) == 0, "illegal param[val:%d, base:%d]",
                     val, base);
-    return (val + base - 1) & -base;
+    return (val + base - 1) & ~(base - 1);
 }
 
 template <typename T>


### PR DESCRIPTION
I'm currently participating in botw's zeldaret project and I decompiled gsys::MemBuffer::alloc() but I was forced to modify the signature of sead::math::roundUp so that the second parameter takes a u32 instead of an s32 to avoid an exetend sign which would have prevented matching. In addition, it makes no sense to align a number on a negative number. I also took the opportunity to modify the signature of roundUpPow2, roundDownN and roundDownPow2. After my changes, I was able to compile and do tools/check on botw, it didn't break anything.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/222)
<!-- Reviewable:end -->
