### PR TITLE
prim: Add specific  `RTTI` implementation for mods

### DIFF
--- a/include/prim/seadRuntimeTypeInfo.h
+++ b/include/prim/seadRuntimeTypeInfo.h
@@ -50,7 +50,7 @@ inline bool IsDerivedFrom(const Type* obj)
 }
 
 /// If the object is a DerivedType or any type that derives from (i.e. inherits) DerivedType,
-/// this returns obj casted to DerivedType* -- otherwise this returns nullptr.
+/// this returns obj cast to DerivedType* -- otherwise this returns nullptr.
 ///
 /// @note This is similar to C++'s dynamic_cast or LLVM's dyn_cast but only works with types
 /// that use the sead RTTI mechanism.
@@ -65,32 +65,39 @@ inline DerivedType* DynamicCast(Type* obj)
 
 }  // namespace sead
 
+#if SEAD_TARGET == SEAD_TARGET_DECOMP
 #if SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_RETURNS_INSTANCE
+
 #define SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_BASE(CLASS)                                          \
     virtual const CLASS* checkDerivedRuntimeTypeInfo(                                              \
         const sead::RuntimeTypeInfo::Interface* typeInfo) const                                    \
     {                                                                                              \
         return checkDerivedRuntimeTypeInfoStatic(typeInfo) ? this : nullptr;                       \
     }
+
 #define SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_OVERRIDE(CLASS)                                      \
     const CLASS* checkDerivedRuntimeTypeInfo(const sead::RuntimeTypeInfo::Interface* typeInfo)     \
         const override                                                                             \
     {                                                                                              \
         return checkDerivedRuntimeTypeInfoStatic(typeInfo) ? this : nullptr;                       \
     }
+
 #else
+
 #define SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_BASE(CLASS)                                          \
     virtual bool checkDerivedRuntimeTypeInfo(const sead::RuntimeTypeInfo::Interface* typeInfo)     \
         const                                                                                      \
     {                                                                                              \
         return checkDerivedRuntimeTypeInfoStatic(typeInfo);                                        \
     }
+
 #define SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_OVERRIDE(CLASS)                                      \
     bool checkDerivedRuntimeTypeInfo(const sead::RuntimeTypeInfo::Interface* typeInfo)             \
         const override                                                                             \
     {                                                                                              \
         return checkDerivedRuntimeTypeInfoStatic(typeInfo);                                        \
     }
+
 #endif
 
 /// Use this macro to declare sead RTTI machinery for a base class.
@@ -146,5 +153,121 @@ public:                                                                         
     {                                                                                              \
         return getRuntimeTypeInfoStatic();                                                         \
     }
+
+#elif SEAD_TARGET == SEAD_TARGET_MOD
+#if SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_RETURNS_INSTANCE
+
+#define SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_BASE(CLASS)                                          \
+    virtual const CLASS* checkDerivedRuntimeTypeInfo(                                              \
+        const sead::RuntimeTypeInfo::Interface* typeInfo) const;
+
+#define SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_OVERRIDE(CLASS)                                      \
+    const CLASS* checkDerivedRuntimeTypeInfo(const sead::RuntimeTypeInfo::Interface* typeInfo)     \
+        const override;
+
+#define SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_BASE_CUSTOM(CLASS)                                   \
+    virtual const CLASS* checkDerivedRuntimeTypeInfo(                                              \
+        const sead::RuntimeTypeInfo::Interface* typeInfo) const                                    \
+    {                                                                                              \
+        return checkDerivedRuntimeTypeInfoStatic(typeInfo) ? this : nullptr;                       \
+    }
+
+#define SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_OVERRIDE_CUSTOM(CLASS)                               \
+    const CLASS* checkDerivedRuntimeTypeInfo(const sead::RuntimeTypeInfo::Interface* typeInfo)     \
+        const override                                                                             \
+    {                                                                                              \
+        return checkDerivedRuntimeTypeInfoStatic(typeInfo) ? this : nullptr;                       \
+    }
+
+#else
+
+#define SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_BASE(CLASS)                                          \
+    virtual bool checkDerivedRuntimeTypeInfo(const sead::RuntimeTypeInfo::Interface* typeInfo)     \
+        const;
+
+#define SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_OVERRIDE(CLASS)                                      \
+    bool checkDerivedRuntimeTypeInfo(const sead::RuntimeTypeInfo::Interface* typeInfo)             \
+        const override;
+
+#define SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_BASE_CUSTOM(CLASS)                                   \
+    virtual bool checkDerivedRuntimeTypeInfo(const sead::RuntimeTypeInfo::Interface* typeInfo)     \
+        const                                                                                      \
+    {                                                                                              \
+        return checkDerivedRuntimeTypeInfoStatic(typeInfo);                                        \
+    }
+
+#define SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_OVERRIDE_CUSTOM(CLASS)                               \
+    bool checkDerivedRuntimeTypeInfo(const sead::RuntimeTypeInfo::Interface* typeInfo)             \
+        const override                                                                             \
+    {                                                                                              \
+        return checkDerivedRuntimeTypeInfoStatic(typeInfo);                                        \
+    }
+
+#endif
+
+#define SEAD_RTTI_BASE(CLASS)                                                                      \
+public:                                                                                            \
+    SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_BASE(CLASS)                                              \
+                                                                                                   \
+    virtual const sead::RuntimeTypeInfo::Interface* getRuntimeTypeInfo() const;
+
+#define SEAD_RTTI_OVERRIDE(CLASS, BASE)                                                            \
+public:                                                                                            \
+    SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_OVERRIDE(CLASS)                                          \
+                                                                                                   \
+    const sead::RuntimeTypeInfo::Interface* getRuntimeTypeInfo() const override;
+
+#define SEAD_RTTI_BASE_CUSTOM(CLASS)                                                               \
+public:                                                                                            \
+    static const sead::RuntimeTypeInfo::Interface* getRuntimeTypeInfoStatic()                      \
+    {                                                                                              \
+        static const sead::RuntimeTypeInfo::Root typeInfo;                                         \
+        return &typeInfo;                                                                          \
+    }                                                                                              \
+                                                                                                   \
+    static bool checkDerivedRuntimeTypeInfoStatic(                                                 \
+        const sead::RuntimeTypeInfo::Interface* typeInfo)                                          \
+    {                                                                                              \
+        const sead::RuntimeTypeInfo::Interface* clsTypeInfo = CLASS::getRuntimeTypeInfoStatic();   \
+        return typeInfo == clsTypeInfo;                                                            \
+    }                                                                                              \
+                                                                                                   \
+    SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_BASE_CUSTOM(CLASS)                                       \
+                                                                                                   \
+    virtual const sead::RuntimeTypeInfo::Interface* getRuntimeTypeInfo() const                     \
+    {                                                                                              \
+        return getRuntimeTypeInfoStatic();                                                         \
+    }
+
+/// Use this macro to declare sead RTTI machinery for a derived class.
+/// @param CLASS The name of the class.
+/// @param BASE The name of the base class of CLASS.
+#define SEAD_RTTI_OVERRIDE_CUSTOM(CLASS, BASE)                                                     \
+public:                                                                                            \
+    static const sead::RuntimeTypeInfo::Interface* getRuntimeTypeInfoStatic()                      \
+    {                                                                                              \
+        static const sead::RuntimeTypeInfo::Derive<BASE> typeInfo;                                 \
+        return &typeInfo;                                                                          \
+    }                                                                                              \
+                                                                                                   \
+    static bool checkDerivedRuntimeTypeInfoStatic(                                                 \
+        const sead::RuntimeTypeInfo::Interface* typeInfo)                                          \
+                                                                                                   \
+    {                                                                                              \
+        const sead::RuntimeTypeInfo::Interface* clsTypeInfo = CLASS::getRuntimeTypeInfoStatic();   \
+        if (typeInfo == clsTypeInfo)                                                               \
+            return true;                                                                           \
+                                                                                                   \
+        return BASE::checkDerivedRuntimeTypeInfoStatic(typeInfo);                                  \
+    }                                                                                              \
+                                                                                                   \
+    SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_OVERRIDE_CUSTOM(CLASS)                                   \
+                                                                                                   \
+    const sead::RuntimeTypeInfo::Interface* getRuntimeTypeInfo() const override                    \
+    {                                                                                              \
+        return getRuntimeTypeInfoStatic();                                                         \
+    }
+
+#endif
 
 #endif  // SEAD_RUNTIMETYPEINFO_H_

--- a/include/prim/seadRuntimeTypeInfo.h
+++ b/include/prim/seadRuntimeTypeInfo.h
@@ -172,11 +172,14 @@ public:                                                                         
         return checkDerivedRuntimeTypeInfoStatic(typeInfo) ? this : nullptr;                       \
     }
 
-#define SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_OVERRIDE_CUSTOM(CLASS)                               \
+#define SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_OVERRIDE_CUSTOM(CLASS, BASE)                         \
     const CLASS* checkDerivedRuntimeTypeInfo(const sead::RuntimeTypeInfo::Interface* typeInfo)     \
         const override                                                                             \
     {                                                                                              \
-        return checkDerivedRuntimeTypeInfoStatic(typeInfo) ? this : nullptr;                       \
+        return (checkDerivedRuntimeTypeInfoStatic(typeInfo) ||                                     \
+                this->BASE::checkDerivedRuntimeTypeInfo(typeInfo)) ?                               \
+                   this :                                                                          \
+                   nullptr;                                                                        \
     }
 
 #else
@@ -196,11 +199,12 @@ public:                                                                         
         return checkDerivedRuntimeTypeInfoStatic(typeInfo);                                        \
     }
 
-#define SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_OVERRIDE_CUSTOM(CLASS)                               \
+#define SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_OVERRIDE_CUSTOM(CLASS, BASE)                         \
     bool checkDerivedRuntimeTypeInfo(const sead::RuntimeTypeInfo::Interface* typeInfo)             \
         const override                                                                             \
     {                                                                                              \
-        return checkDerivedRuntimeTypeInfoStatic(typeInfo);                                        \
+        return checkDerivedRuntimeTypeInfoStatic(typeInfo) ||                                      \
+               this->BASE::checkDerivedRuntimeTypeInfo(typeInfo);                                  \
     }
 
 #endif
@@ -255,13 +259,10 @@ public:                                                                         
                                                                                                    \
     {                                                                                              \
         const sead::RuntimeTypeInfo::Interface* clsTypeInfo = CLASS::getRuntimeTypeInfoStatic();   \
-        if (typeInfo == clsTypeInfo)                                                               \
-            return true;                                                                           \
-                                                                                                   \
-        return BASE::checkDerivedRuntimeTypeInfoStatic(typeInfo);                                  \
+        return typeInfo == clsTypeInfo;                                                            \
     }                                                                                              \
                                                                                                    \
-    SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_OVERRIDE_CUSTOM(CLASS)                                   \
+    SEAD_RTTI_CHECKDERIVEDRUNTIMETYPEINFO_OVERRIDE_CUSTOM(CLASS, BASE)                             \
                                                                                                    \
     const sead::RuntimeTypeInfo::Interface* getRuntimeTypeInfo() const override                    \
     {                                                                                              \

--- a/include/seadVersion.h
+++ b/include/seadVersion.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#define SEAD_TARGET_DECOMP 1
+#define SEAD_TARGET_MOD 2
+
+#ifndef SEAD_TARGET
+#define SEAD_TARGET SEAD_TARGET_DECOMP
+#endif
+
 #define SEAD_VERSION_BOTW 1
 #define SEAD_VERSION_SMO 2
 #define SEAD_VERSION_SPL3 3


### PR DESCRIPTION
This PR add specific `RTTI` implementation for mods that allow the modding framework to call game functions instead of redefining them in your mod. To use this feature, you have to define `SEAD_TARGET` to 2 and then use `SEAD_RTTI_BASE_CUSTOM` or `SEAD_RTTI_OVERRIDE_CUSTOM` in your mod headers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/251)
<!-- Reviewable:end -->
