### PR TITLE
time: Add default to `DateTime(u64)`

### DIFF
--- a/include/time/seadDateTime.h
+++ b/include/time/seadDateTime.h
@@ -11,7 +11,7 @@ class DateTimeUtc;
 class DateTime
 {
 public:
-    DateTime(u64 unix_time);
+    DateTime(u64 unix_time = 0);
     DateTime(const CalendarTime& time);
     DateTime(const CalendarTime::Year& year, const CalendarTime::Month& month,
              const CalendarTime::Day& day, const CalendarTime::Hour& hour,


### PR DESCRIPTION
Most calls to this constructor have `0` as the value here, so let's just put that as the default to avoid specifying it everywhere.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/252)
<!-- Reviewable:end -->
