### PR TITLE
container: Fix `FreeList::setWork`

### DIFF
--- a/include/container/seadFreeList.h
+++ b/include/container/seadFreeList.h
@@ -37,16 +37,17 @@ inline void FreeList::setWork(void* work, s32 elem_size, s32 num)
     SEAD_ASSERT(elem_size > 0 && elem_size % cPtrSize == 0);
     SEAD_ASSERT(num > 0);
 
-    const s32 idx_multiplier = elem_size / cPtrSize;
-    void** const ptrs = new (work) void*[num * idx_multiplier];
+    const s32 nodeSize = elem_size / cPtrSize;
+    FreeList::Node* nodes = reinterpret_cast<FreeList::Node*>(work);
 
-    mFree = new (work) Node;
+    mFree = &nodes[0];
 
     // Create the linked list.
     for (s32 i = 0; i < num - 1; ++i)
-        new (&ptrs[i * idx_multiplier]) Node{new (&ptrs[(i + 1) * idx_multiplier]) Node};
+        nodes[i * nodeSize].nextFree = &nodes[(i + 1) * nodeSize];
 
-    new (&ptrs[(num - 1) * idx_multiplier]) Node{nullptr};
+    // TODO: Check why casting is necessary
+    nodes[(s32)((u32)(num - 1) * nodeSize)].nextFree = nullptr;
 
     mWork = work;
 }


### PR DESCRIPTION
A chaotic evil developer decided to use new allocators as some sort of memory getter. Long story sort this code is cursed and doesn't match.

This function doesn't initialize the memory at all. It just builds the linked list. For this reason I decided to use reinterpret cast to transform the work buffer into something we can use. This also fully matches the function.

Ideally the Node should have a variable size. So all operations lineup perfectly but c++ doesn't support dynamic arrays.

Proof of work ->https://decomp.me/scratch/L2Yrq

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/254)
<!-- Reviewable:end -->
