### PR TITLE
cointainer: Fix `PtrArray` end iterator

### DIFF
--- a/include/container/seadPtrArray.h
+++ b/include/container/seadPtrArray.h
@@ -313,8 +313,8 @@ public:
         T* const* mPPtr;
     };
 
-    iterator begin() const { return iterator(data()); }
-    iterator end() const { return iterator(data() + mPtrNum); }
+    iterator begin() const { return iterator(dataBegin()); }
+    iterator end() const { return iterator(dataEnd()); }
 
     class constIterator
     {
@@ -334,12 +334,12 @@ public:
         const T* const* mPPtr;
     };
 
-    constIterator constBegin() const { return constIterator(data()); }
-    constIterator constEnd() const { return constIterator(data() + mPtrNum); }
+    constIterator constBegin() const { return constIterator(dataBegin()); }
+    constIterator constEnd() const { return constIterator(dataEnd()); }
 
     T** data() const { return reinterpret_cast<T**>(mPtrs); }
     T** dataBegin() const { return data(); }
-    T** dataEnd() const { return data() + mPtrNum; }
+    T** dataEnd() const { return &data()[mPtrNum]; }
 
 protected:
     static void* constCast(const T* ptr)

--- a/modules/src/controller/seadControllerMgr.cpp
+++ b/modules/src/controller/seadControllerMgr.cpp
@@ -84,7 +84,6 @@ void ControllerMgr::finalizeDefault()
     finalize();
 }
 
-// NON_MATCHING: swapped ldr / ldrsw on second loop check
 void ControllerMgr::calc()
 {
     for (auto it = mDevices.begin(); it != mDevices.end(); ++it)


### PR DESCRIPTION
This changes the order at which the data is obtained. Required to match https://decomp.me/scratch/wA6rB also fixes the mismatch at `sead::ControllerMgr::calc`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/257)
<!-- Reviewable:end -->
