### PR TITLE
heap: Add default on `ScopedCurrentHeapSetter::mPreviousHeap`

### DIFF
--- a/include/heap/seadHeapMgr.h
+++ b/include/heap/seadHeapMgr.h
@@ -123,7 +123,7 @@ protected:
         return reinterpret_cast<Heap*>(mPreviousHeap) != reinterpret_cast<Heap*>(1);
     }
 
-    uintptr_t mPreviousHeap;
+    uintptr_t mPreviousHeap = 0;
 };
 
 class FindContainHeapCache


### PR DESCRIPTION
needs to be `= 0` for matching the `al::SceneHeapSetter` constructor in odyssey, thanks @german77

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/259)
<!-- Reviewable:end -->
