### PR TITLE
heap: Add defaults to `FrameHeap::[try]Create`

### DIFF
--- a/include/heap/seadFrameHeap.h
+++ b/include/heap/seadFrameHeap.h
@@ -15,13 +15,13 @@ public:
     };
 
     static FrameHeap* tryCreate(size_t size, const SafeString& name, Heap* parent,
-                              s32 alignment = sizeof(void*),
-                              HeapDirection direction = cHeapDirection_Forward,
-                              bool enable_lock = false);
+                                s32 alignment = sizeof(void*),
+                                HeapDirection direction = cHeapDirection_Forward,
+                                bool enable_lock = false);
     static FrameHeap* create(size_t size, const SafeString& name, Heap* parent,
-                           s32 alignment = sizeof(void*),
-                           HeapDirection direction = cHeapDirection_Forward,
-                           bool enable_lock = false);
+                             s32 alignment = sizeof(void*),
+                             HeapDirection direction = cHeapDirection_Forward,
+                             bool enable_lock = false);
 
     static size_t getManagementAreaSize(s32);
 

--- a/include/heap/seadFrameHeap.h
+++ b/include/heap/seadFrameHeap.h
@@ -14,10 +14,14 @@ public:
         void* mTailPtr;
     };
 
-    static FrameHeap* tryCreate(size_t size, const SafeString& name, Heap* parent, s32,
-                                HeapDirection direction, bool);
-    static FrameHeap* create(size_t size, const SafeString& name, Heap* parent, s32,
-                             HeapDirection direction, bool);
+    static FrameHeap* tryCreate(size_t size, const SafeString& name, Heap* parent,
+                              s32 alignment = sizeof(void*),
+                              HeapDirection direction = cHeapDirection_Forward,
+                              bool enable_lock = false);
+    static FrameHeap* create(size_t size, const SafeString& name, Heap* parent,
+                           s32 alignment = sizeof(void*),
+                           HeapDirection direction = cHeapDirection_Forward,
+                           bool enable_lock = false);
 
     static size_t getManagementAreaSize(s32);
 


### PR DESCRIPTION
Similar to what is done in `ExpHeap.h`. The same values seem to be used by default.

To be used by https://github.com/MonsterDruide1/OdysseyDecomp/pull/904

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/260)
<!-- Reviewable:end -->
