### PR TITLE
filedevice: Make `ArchiveFileDevice::getArchiveFileHandle_` non-const

### DIFF
--- a/include/filedevice/seadArchiveFileDevice.h
+++ b/include/filedevice/seadArchiveFileDevice.h
@@ -47,7 +47,7 @@ protected:
     virtual s32 doConvertPathToEntryID_(const SafeString& path);
     virtual bool doSetCurrentDirectory_(const SafeString& path);
 
-    ArchiveFileHandle* getArchiveFileHandle_(FileHandle* handle) const;
+    ArchiveFileHandle* getArchiveFileHandle_(FileHandle* handle);
     ArchiveFileHandle* constructArchiveFileHandle_(FileHandle* handle) const;
 
     ArchiveRes* mArchive;

--- a/modules/src/filedevice/seadArchiveFileDevice.cpp
+++ b/modules/src/filedevice/seadArchiveFileDevice.cpp
@@ -92,7 +92,7 @@ bool ArchiveFileDevice::doGetFileSize_(u32* fileSize, FileHandle* handle)
 }
 
 ArchiveFileDevice::ArchiveFileHandle*
-ArchiveFileDevice::getArchiveFileHandle_(FileHandle* handle) const
+ArchiveFileDevice::getArchiveFileHandle_(FileHandle* handle)
 {
     return reinterpret_cast<ArchiveFileHandle*>(getHandleBaseHandleBuffer_(handle).getBufferPtr());
 }

--- a/modules/src/filedevice/seadArchiveFileDevice.cpp
+++ b/modules/src/filedevice/seadArchiveFileDevice.cpp
@@ -91,8 +91,7 @@ bool ArchiveFileDevice::doGetFileSize_(u32* fileSize, FileHandle* handle)
     return true;
 }
 
-ArchiveFileDevice::ArchiveFileHandle*
-ArchiveFileDevice::getArchiveFileHandle_(FileHandle* handle)
+ArchiveFileDevice::ArchiveFileHandle* ArchiveFileDevice::getArchiveFileHandle_(FileHandle* handle)
 {
     return reinterpret_cast<ArchiveFileHandle*>(getHandleBaseHandleBuffer_(handle).getBufferPtr());
 }


### PR DESCRIPTION
The symbol in Odyssey is just `_ZN4sead17ArchiveFileDevice21getArchiveFileHandle_EPNS_10FileHandleE`, marking it as non-`const` function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/264)
<!-- Reviewable:end -->
