### PR TITLE
prim: Add file initializer to `seadEnum`

### DIFF
--- a/modules/src/prim/seadEnum.cpp
+++ b/modules/src/prim/seadEnum.cpp
@@ -7,6 +7,9 @@ namespace
 class EnumParseTextCriticalSection
 {
 public:
+    EnumParseTextCriticalSection() {
+        (void) getObject();  // force initialization of sObject
+    }
     sead::CriticalSection* getObject()
     {
         static sead::CriticalSection sObject;
@@ -18,6 +21,9 @@ static EnumParseTextCriticalSection sEnumParseTextCriticalSection;
 class EnumInitValueArrayCriticalSection
 {
 public:
+    EnumInitValueArrayCriticalSection() {
+        (void) getObject();  // force initialization of sObject
+    }
     sead::CriticalSection* getObject()
     {
         static sead::CriticalSection sObject;

--- a/modules/src/prim/seadEnum.cpp
+++ b/modules/src/prim/seadEnum.cpp
@@ -7,8 +7,9 @@ namespace
 class EnumParseTextCriticalSection
 {
 public:
-    EnumParseTextCriticalSection() {
-        (void) getObject();  // force initialization of sObject
+    EnumParseTextCriticalSection()
+    {
+        (void)getObject();  // force initialization of sObject
     }
     sead::CriticalSection* getObject()
     {
@@ -21,8 +22,9 @@ static EnumParseTextCriticalSection sEnumParseTextCriticalSection;
 class EnumInitValueArrayCriticalSection
 {
 public:
-    EnumInitValueArrayCriticalSection() {
-        (void) getObject();  // force initialization of sObject
+    EnumInitValueArrayCriticalSection()
+    {
+        (void)getObject();  // force initialization of sObject
     }
     sead::CriticalSection* getObject()
     {


### PR DESCRIPTION
SMO shows a function which fetches the `sObject` of both classes once within `.init_array` - to re-construct that, the constructor can just call into `getObject()` and discard the result, such that `sObject` must be prepared (and fetched) on game boot.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/265)
<!-- Reviewable:end -->
