### PR TITLE
time: Implement `DateTime::DateTime(const DateTimeUtc&)`

### DIFF
--- a/include/time/seadDateTime.h
+++ b/include/time/seadDateTime.h
@@ -16,6 +16,7 @@ public:
     DateTime(const CalendarTime::Year& year, const CalendarTime::Month& month,
              const CalendarTime::Day& day, const CalendarTime::Hour& hour,
              const CalendarTime::Minute& minute, const CalendarTime::Second& second);
+    DateTime(const DateTimeUtc& unused);
 
     DateTime& operator+=(DateSpan span)
     {

--- a/modules/src/time/seadDateTime.cpp
+++ b/modules/src/time/seadDateTime.cpp
@@ -126,6 +126,26 @@ DateTime::DateTime(const CalendarTime::Year& year, const CalendarTime::Month& mo
     setUnixTime(year, month, day, hour, minute, second);
 }
 
+DateTime::DateTime(const DateTimeUtc& unused)
+{
+#ifdef NNSDK
+    initializeSystemTimeModule();
+
+    nn::time::CalendarTime ctime;
+    // BUG: uses uninitialized `mUnixTime` instead of parameter `time`.
+    nn::time::PosixTime time = {mUnixTime};
+    nn::time::ToCalendarTime(&ctime, nullptr, time);
+
+    const auto year = CalendarTime::Year(ctime.year);
+    const auto month = CalendarTime::Month::makeFromValueOneOrigin(ctime.month);
+    const auto day = CalendarTime::Day(ctime.day);
+    const auto hour = CalendarTime::Hour(ctime.hour);
+    const auto minute = CalendarTime::Minute(ctime.minute);
+    const auto second = CalendarTime::Second(ctime.second);
+    setUnixTime(year, month, day, hour, minute, second);
+#endif
+}
+
 u64 DateTime::setNow()
 {
 #ifdef NNSDK

--- a/modules/src/time/seadDateTime.cpp
+++ b/modules/src/time/seadDateTime.cpp
@@ -126,7 +126,7 @@ DateTime::DateTime(const CalendarTime::Year& year, const CalendarTime::Month& mo
     setUnixTime(year, month, day, hour, minute, second);
 }
 
-DateTime::DateTime(const DateTimeUtc& unused)
+DateTime::DateTime([[maybe_unused]] const DateTimeUtc& unused)
 {
 #ifdef NNSDK
     initializeSystemTimeModule();


### PR DESCRIPTION
Note that this function is pure nonsense in terms of functionality: Instead of using the parameter for assigning a time, it uses the (uninitialized) memory already present in the class. So it's effectively more like a (bad) RNG for time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/266)
<!-- Reviewable:end -->
