### PR TITLE
all: Fix typeinfo size

### DIFF
--- a/include/framework/seadTaskMgr.h
+++ b/include/framework/seadTaskMgr.h
@@ -13,7 +13,7 @@ class Framework;
 class Heap;
 class NullFaderTask;
 
-class TaskMgr final : sead::hostio::Node
+class TaskMgr final : public sead::hostio::Node
 {
 public:
     struct InitializeArg

--- a/include/heap/seadHeapMgr.h
+++ b/include/heap/seadHeapMgr.h
@@ -13,7 +13,7 @@
 
 namespace sead
 {
-class HeapMgr : hostio::Node
+class HeapMgr : public hostio::Node
 {
     struct AllocCallbackArg;
     struct CreateCallbackArg;


### PR DESCRIPTION
As dumb as it looks this actually fixes typeinfo size mismatch

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/270)
<!-- Reviewable:end -->
