### PR TITLE
prim: remove auto from seadDelegate

### DIFF
--- a/include/prim/seadDelegate.h
+++ b/include/prim/seadDelegate.h
@@ -358,8 +358,8 @@ class LambdaDelegate : public IDelegate
 {
 public:
     explicit LambdaDelegate(Lambda l) : mLambda(std::move(l)) {}
-    auto invoke() override { return mLambda(); }
-    auto operator()() const { return mLambda(); }
+    void invoke() override { mLambda(); }
+    void operator()() const { mLambda(); }
     LambdaDelegate* clone(Heap* heap) const override { return new (heap) LambdaDelegate(*this); }
 
 protected:
@@ -384,8 +384,8 @@ class LambdaDelegate1 : public IDelegate1<A1>
 {
 public:
     explicit LambdaDelegate1(Lambda l) : mLambda(std::move(l)) {}
-    auto invoke(A1 a1) override { return mLambda(a1); }
-    auto operator()(A1 a1) const { return mLambda(a1); }
+    void invoke(A1 a1) override { mLambda(a1); }
+    void operator()(A1 a1) const { mLambda(a1); }
     LambdaDelegate1* clone(Heap* heap) const override { return new (heap) LambdaDelegate1(*this); }
 
 protected:
@@ -413,8 +413,8 @@ class LambdaDelegate2 : public IDelegate2<A1, A2>
 {
 public:
     explicit LambdaDelegate2(Lambda l) : mLambda(std::move(l)) {}
-    auto invoke(A1 a1, A2 a2) override { return mLambda(a1, a2); }
-    auto operator()(A1 a1, A2 a2) const { return mLambda(a1, a2); }
+    void invoke(A1 a1, A2 a2) override { mLambda(a1, a2); }
+    void operator()(A1 a1, A2 a2) const { mLambda(a1, a2); }
     LambdaDelegate2* clone(Heap* heap) const override { return new (heap) LambdaDelegate2(*this); }
 
 protected:
@@ -428,7 +428,10 @@ public:
     explicit LambdaDelegate2R(Lambda l) : mLambda(std::move(l)) {}
     R invoke(A1 a1, A2 a2) override { return mLambda(a1, a2); }
     R operator()(A1 a1, A2 a2) const { return mLambda(a1, a2); }
-    LambdaDelegate2R clone(Heap* heap) const override { return new (heap) LambdaDelegate2R(*this); }
+    LambdaDelegate2R* clone(Heap* heap) const override
+    {
+        return new (heap) LambdaDelegate2R(*this);
+    }
 
 protected:
     Lambda mLambda;

--- a/include/prim/seadDelegate.h
+++ b/include/prim/seadDelegate.h
@@ -580,11 +580,17 @@ public:
     class UnbindDummy final : public Base::Interface_
     {
     public:
+        UnbindDummy() {}
         R invoke() override { return {}; }
 #if SEAD_DELEGATE_ISNODUMMY
         bool isNoDummy() const override { return false; }
 #endif
+    private:
+        s32 mUnk = 1;
     };
+
+    AnyDelegateR() {}
+
     using Base::Base;
     using Base::operator=;
 };

--- a/include/prim/seadDelegate.h
+++ b/include/prim/seadDelegate.h
@@ -360,7 +360,7 @@ public:
     explicit LambdaDelegate(Lambda l) : mLambda(std::move(l)) {}
     auto invoke() override { return mLambda(); }
     auto operator()() const { return mLambda(); }
-    auto clone(Heap* heap) const override { return new (heap) LambdaDelegate(*this); }
+    LambdaDelegate* clone(Heap* heap) const override { return new (heap) LambdaDelegate(*this); }
 
 protected:
     Lambda mLambda;
@@ -371,9 +371,9 @@ class LambdaDelegateR : public IDelegateR<R>
 {
 public:
     explicit LambdaDelegateR(Lambda l) : mLambda(std::move(l)) {}
-    auto invoke() override { return mLambda(); }
-    auto operator()() const { return mLambda(); }
-    auto clone(Heap* heap) const override { return new (heap) LambdaDelegateR(*this); }
+    R invoke() override { return mLambda(); }
+    R operator()() const { return mLambda(); }
+    LambdaDelegateR* clone(Heap* heap) const override { return new (heap) LambdaDelegateR(*this); }
 
 protected:
     Lambda mLambda;
@@ -386,7 +386,7 @@ public:
     explicit LambdaDelegate1(Lambda l) : mLambda(std::move(l)) {}
     auto invoke(A1 a1) override { return mLambda(a1); }
     auto operator()(A1 a1) const { return mLambda(a1); }
-    auto clone(Heap* heap) const override { return new (heap) LambdaDelegate1(*this); }
+    LambdaDelegate1* clone(Heap* heap) const override { return new (heap) LambdaDelegate1(*this); }
 
 protected:
     Lambda mLambda;
@@ -397,9 +397,12 @@ class LambdaDelegate1R : public IDelegate1R<A1, R>
 {
 public:
     explicit LambdaDelegate1R(Lambda l) : mLambda(std::move(l)) {}
-    auto invoke(A1 a1) override { return mLambda(a1); }
-    auto operator()(A1 a1) const { return mLambda(a1); }
-    auto clone(Heap* heap) const override { return new (heap) LambdaDelegate1R(*this); }
+    R invoke(A1 a1) override { return mLambda(a1); }
+    R operator()(A1 a1) const { return mLambda(a1); }
+    LambdaDelegate1R* clone(Heap* heap) const override
+    {
+        return new (heap) LambdaDelegate1R(*this);
+    }
 
 protected:
     Lambda mLambda;
@@ -412,7 +415,7 @@ public:
     explicit LambdaDelegate2(Lambda l) : mLambda(std::move(l)) {}
     auto invoke(A1 a1, A2 a2) override { return mLambda(a1, a2); }
     auto operator()(A1 a1, A2 a2) const { return mLambda(a1, a2); }
-    auto clone(Heap* heap) const override { return new (heap) LambdaDelegate2(*this); }
+    LambdaDelegate2* clone(Heap* heap) const override { return new (heap) LambdaDelegate2(*this); }
 
 protected:
     Lambda mLambda;
@@ -423,9 +426,9 @@ class LambdaDelegate2R : public IDelegate2R<A1, A2, R>
 {
 public:
     explicit LambdaDelegate2R(Lambda l) : mLambda(std::move(l)) {}
-    auto invoke(A1 a1, A2 a2) override { return mLambda(a1, a2); }
-    auto operator()(A1 a1, A2 a2) const { return mLambda(a1, a2); }
-    auto clone(Heap* heap) const override { return new (heap) LambdaDelegate2R(*this); }
+    R invoke(A1 a1, A2 a2) override { return mLambda(a1, a2); }
+    R operator()(A1 a1, A2 a2) const { return mLambda(a1, a2); }
+    LambdaDelegate2R clone(Heap* heap) const override { return new (heap) LambdaDelegate2R(*this); }
 
 protected:
     Lambda mLambda;


### PR DESCRIPTION
The compiler can't determine the correct type to use with auto. Return discrete types instead. Required by SMO  SphinxRide::exeDemoStandbyStart https://decomp.me/scratch/FEAN1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/271)
<!-- Reviewable:end -->
