### PR TITLE
math: Implement `MathCalcCommon::isNan` and `vectorx::isNan`

### DIFF
--- a/include/math/seadMathCalcCommon.hpp
+++ b/include/math/seadMathCalcCommon.hpp
@@ -529,6 +529,12 @@ inline T MathCalcCommon<T>::clamp(T value, T low, T high)
 }
 
 template <typename T>
+inline bool MathCalcCommon<T>::isNan(T value)
+{
+    return std::isnan(value);
+}
+
+template <typename T>
 inline bool MathCalcCommon<T>::chase(T* value, T target, T step)
 {
     const T current = *value;

--- a/include/math/seadVector.h
+++ b/include/math/seadVector.h
@@ -69,6 +69,7 @@ struct Vector2 : public Policies<T>::Vec2Base
     T normalize();
 
     bool isZero() const { return *this == zero; }
+    bool isNan() const { return sead::Mathf::isNan(this->x) || sead::Mathf::isNan(this->y); }
 
     static const Vector2 zero;
     static const Vector2 ex;
@@ -190,6 +191,12 @@ struct Vector3 : public Policies<T>::Vec3Base
     void setRotated(const Quat& q, const Vector3& a);
     void setSub(const Vector3& a, const Vector3& b);
 
+    bool isNan() const
+    {
+        return sead::Mathf::isNan(this->x) || sead::Mathf::isNan(this->y) ||
+               sead::Mathf::isNan(this->z);
+    }
+
     static const Vector3 zero;
     static const Vector3 ex;
     static const Vector3 ey;
@@ -243,6 +250,12 @@ struct Vector4 : public Policies<T>::Vec4Base
     T squaredLength() const;
     void set(const Vector4& v);
     void set(T x_, T y_, T z_, T w_);
+
+    bool isNan() const
+    {
+        return sead::Mathf::isNan(this->x) || sead::Mathf::isNan(this->y) ||
+               sead::Mathf::isNan(this->z) || sead::Mathf::isNan(this->w);
+    }
 
     static const Vector4 zero;
     static const Vector4 ex;


### PR DESCRIPTION
Required for NavMeshCharacter::updatePhysics in botw https://decomp.me/scratch/05OjR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/sead/272)
<!-- Reviewable:end -->
